### PR TITLE
CIV IV Bugfixes

### DIFF
--- a/CvDLLWidgetData.cpp
+++ b/CvDLLWidgetData.cpp
@@ -1,0 +1,4528 @@
+#include "CvGameCoreDLL.h"
+#include "CvGameCoreUtils.h"
+#include "CvCity.h"
+#include "CvUnit.h"
+#include "CvGlobals.h"
+#include "CvGameAI.h"
+#include "CvMap.h"
+#include "CvPlot.h"
+#include "CvTeamAI.h"
+#include "CvPlayerAI.h"
+#include "CvGameCoreUtils.h"
+#include "CyArgsList.h"
+#include "CvGameTextMgr.h"
+#include "CvDLLInterfaceIFaceBase.h"
+#include "CvDLLPythonIFaceBase.h"
+#include "CvDLLEngineIFaceBase.h"
+#include "CvEventReporter.h"
+#include "CvDLLWidgetData.h"
+#include "CvPopupInfo.h"
+#include "FProfiler.h"
+#include "CvMessageControl.h"
+
+CvDLLWidgetData* CvDLLWidgetData::m_pInst = NULL;
+
+CvDLLWidgetData& CvDLLWidgetData::getInstance()
+{
+	if (m_pInst == NULL)
+	{
+		m_pInst = new CvDLLWidgetData;
+	}
+	return *m_pInst;
+}
+
+void CvDLLWidgetData::freeInstance()
+{
+	delete m_pInst;
+	m_pInst = NULL;
+}
+
+void CvDLLWidgetData::parseHelp(CvWStringBuffer &szBuffer, CvWidgetDataStruct &widgetDataStruct)
+{
+	switch (widgetDataStruct.m_eWidgetType)
+	{
+	case WIDGET_PLOT_LIST:
+		parsePlotListHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_PLOT_LIST_SHIFT:
+		szBuffer.assign(gDLL->getText("TXT_KEY_MISC_CTRL_SHIFT", (GC.getDefineINT("MAX_PLOT_LIST_SIZE") - 1)));
+		break;
+
+	case WIDGET_CITY_SCROLL:
+		break;
+
+	case WIDGET_LIBERATE_CITY:
+		parseLiberateCityHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_CITY_NAME:
+		parseCityNameHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_UNIT_NAME:
+		szBuffer.append(gDLL->getText("TXT_KEY_CHANGE_NAME"));
+		break;
+
+	case WIDGET_CREATE_GROUP:
+		szBuffer.append(gDLL->getText("TXT_KEY_WIDGET_CREATE_GROUP"));
+		break;
+
+	case WIDGET_DELETE_GROUP:
+		szBuffer.append(gDLL->getText("TXT_KEY_WIDGET_DELETE_GROUP"));
+		break;
+
+	case WIDGET_TRAIN:
+		parseTrainHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_CONSTRUCT:
+		parseConstructHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_CREATE:
+		parseCreateHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_MAINTAIN:
+		parseMaintainHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_HURRY:
+		parseHurryHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_MENU_ICON:
+		szBuffer.append(gDLL->getText("TXT_KEY_MAIN_MENU"));
+
+	case WIDGET_CONSCRIPT:
+		parseConscriptHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_ACTION:
+		parseActionHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_CITIZEN:
+		parseCitizenHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_FREE_CITIZEN:
+		parseFreeCitizenHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_DISABLED_CITIZEN:
+		parseDisabledCitizenHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_ANGRY_CITIZEN:
+		parseAngryCitizenHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_CHANGE_SPECIALIST:
+		parseChangeSpecialistHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_RESEARCH:
+		parseResearchHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_TECH_TREE:
+		parseTechTreeHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_CHANGE_PERCENT:
+		parseChangePercentHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_CITY_TAB:
+		{
+			CvWString szTemp;
+            szTemp.Format(L"%s", GC.getCityTabInfo((CityTabTypes)widgetDataStruct.m_iData1).getDescription());
+			szBuffer.assign(szTemp);
+		}
+		break;
+
+	case WIDGET_CONTACT_CIV:
+		parseContactCivHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_SCORE_BREAKDOWN:
+		parseScoreHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_ZOOM_CITY:
+		szBuffer.append(gDLL->getText("TXT_KEY_ZOOM_CITY_HELP"));
+		break;
+
+	case WIDGET_END_TURN:
+		szBuffer.append(gDLL->getText("TXT_KEY_WIDGET_END_TURN"));
+		break;
+		
+	case WIDGET_LAUNCH_VICTORY:
+		szBuffer.append(gDLL->getText("TXT_KEY_WIDGET_LAUNCH_VICTORY"));
+		break;
+
+	case WIDGET_AUTOMATE_CITIZENS:
+		parseAutomateCitizensHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_AUTOMATE_PRODUCTION:
+		parseAutomateProductionHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_EMPHASIZE:
+		parseEmphasizeHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_TRADE_ITEM:
+		parseTradeItem(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_UNIT_MODEL:
+		parseUnitModelHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_FLAG:
+		parseFlagHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_HELP_MAINTENANCE:
+		parseMaintenanceHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_HELP_RELIGION:
+		parseReligionHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_HELP_RELIGION_CITY:
+		parseReligionHelpCity(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_HELP_CORPORATION_CITY:
+		parseCorporationHelpCity(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_HELP_NATIONALITY:
+		parseNationalityHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_HELP_DEFENSE:
+		break;
+
+	case WIDGET_HELP_HEALTH:
+		parseHealthHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_HELP_HAPPINESS:
+		parseHappinessHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_HELP_POPULATION:
+		parsePopulationHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_HELP_PRODUCTION:
+		parseProductionHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_HELP_CULTURE:
+		parseCultureHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_HELP_GREAT_PEOPLE:
+		parseGreatPeopleHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_HELP_GREAT_GENERAL:
+		parseGreatGeneralHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_HELP_SELECTED:
+		parseSelectedHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_HELP_BUILDING:
+		parseBuildingHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_HELP_TRADE_ROUTE_CITY:
+		parseTradeRouteCityHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_HELP_ESPIONAGE_COST:
+		parseEspionageCostHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_HELP_TECH_ENTRY:
+		parseTechEntryHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_HELP_TECH_PREPREQ:
+		parseTechPrereqHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_HELP_OBSOLETE:
+		parseObsoleteHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_HELP_OBSOLETE_BONUS:
+		parseObsoleteBonusString(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_HELP_OBSOLETE_SPECIAL:
+		parseObsoleteSpecialHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_HELP_MOVE_BONUS:
+		parseMoveHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_HELP_FREE_UNIT:
+		parseFreeUnitHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_HELP_FEATURE_PRODUCTION:
+		parseFeatureProductionHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_HELP_WORKER_RATE:
+		parseWorkerRateHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_HELP_TRADE_ROUTES:
+		parseTradeRouteHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_HELP_HEALTH_RATE:
+		parseHealthRateHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_HELP_HAPPINESS_RATE:
+		parseHappinessRateHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_HELP_FREE_TECH:
+		parseFreeTechHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_HELP_LOS_BONUS:
+		parseLOSHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_HELP_MAP_CENTER:
+		parseMapCenterHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_HELP_MAP_REVEAL:
+		parseMapRevealHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_HELP_MAP_TRADE:
+		parseMapTradeHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_HELP_TECH_TRADE:
+		parseTechTradeHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_HELP_GOLD_TRADE:
+		parseGoldTradeHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_HELP_OPEN_BORDERS:
+		parseOpenBordersHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_HELP_DEFENSIVE_PACT:
+		parseDefensivePactHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_HELP_PERMANENT_ALLIANCE:
+		parsePermanentAllianceHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_HELP_VASSAL_STATE:
+		parseVassalStateHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_HELP_BUILD_BRIDGE:
+		parseBuildBridgeHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_HELP_IRRIGATION:
+		parseIrrigationHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_HELP_IGNORE_IRRIGATION:
+		parseIgnoreIrrigationHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_HELP_WATER_WORK:
+		parseWaterWorkHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_HELP_IMPROVEMENT:
+		parseBuildHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_HELP_DOMAIN_EXTRA_MOVES:
+		parseDomainExtraMovesHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_HELP_ADJUST:
+		parseAdjustHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_HELP_TERRAIN_TRADE:
+		parseTerrainTradeHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_HELP_SPECIAL_BUILDING:
+		parseSpecialBuildingHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_HELP_YIELD_CHANGE:
+		parseYieldChangeHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_HELP_BONUS_REVEAL:
+		parseBonusRevealHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_HELP_CIVIC_REVEAL:
+		parseCivicRevealHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_HELP_PROCESS_INFO:
+		parseProcessInfoHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_HELP_FOUND_RELIGION:
+		parseFoundReligionHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_HELP_FOUND_CORPORATION:
+		parseFoundCorporationHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_HELP_FINANCE_NUM_UNITS:
+		parseFinanceNumUnits(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_HELP_FINANCE_UNIT_COST:
+		parseFinanceUnitCost(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_HELP_FINANCE_AWAY_SUPPLY:
+		parseFinanceAwaySupply(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_HELP_FINANCE_CITY_MAINT:
+		parseFinanceCityMaint(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_HELP_FINANCE_CIVIC_UPKEEP:
+		parseFinanceCivicUpkeep(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_HELP_FINANCE_FOREIGN_INCOME:
+		parseFinanceForeignIncome(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_HELP_FINANCE_INFLATED_COSTS:
+		parseFinanceInflatedCosts(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_HELP_FINANCE_GROSS_INCOME:
+		parseFinanceGrossIncome(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_HELP_FINANCE_NET_GOLD:
+		parseFinanceNetGold(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_HELP_FINANCE_GOLD_RESERVE:
+		parseFinanceGoldReserve(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_PEDIA_JUMP_TO_TECH:
+		parseTechEntryHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_PEDIA_JUMP_TO_REQUIRED_TECH:
+		parseTechTreePrereq(widgetDataStruct, szBuffer, false);
+		break;
+
+	case WIDGET_PEDIA_JUMP_TO_DERIVED_TECH:
+		parseTechTreePrereq(widgetDataStruct, szBuffer, true);
+		break;
+
+	case WIDGET_PEDIA_JUMP_TO_UNIT:
+		parseUnitHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_PEDIA_JUMP_TO_BUILDING:
+		parseBuildingHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_PEDIA_BACK:
+		// parsePediaBack(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_PEDIA_FORWARD:
+		// parsePediaForward(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_PEDIA_JUMP_TO_BONUS:
+		parseBonusHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_PEDIA_MAIN:
+		break;
+
+	case WIDGET_PEDIA_JUMP_TO_PROMOTION:
+	case WIDGET_HELP_PROMOTION:
+		parsePromotionHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_CHOOSE_EVENT:
+		parseEventHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_PEDIA_JUMP_TO_UNIT_COMBAT:
+		parseUnitCombatHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_PEDIA_JUMP_TO_IMPROVEMENT:
+		parseImprovementHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_PEDIA_JUMP_TO_CIVIC:
+		parseCivicHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_PEDIA_JUMP_TO_CIV:
+		parseCivilizationHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_PEDIA_JUMP_TO_LEADER:
+		parseLeaderHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_PEDIA_JUMP_TO_SPECIALIST:
+		if (widgetDataStruct.m_iData1 != NO_SPECIALIST && widgetDataStruct.m_iData2 != 0)
+		{
+			CvWString szTemp;
+			szTemp.Format(L"%s", GC.getSpecialistInfo((SpecialistTypes)widgetDataStruct.m_iData1).getDescription());
+			szBuffer.assign(szTemp);
+		}
+		break;
+
+	case WIDGET_PEDIA_JUMP_TO_PROJECT:
+		parseProjectHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_PEDIA_JUMP_TO_RELIGION:
+		parseReligionHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_PEDIA_JUMP_TO_CORPORATION:
+		parseCorporationHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_PEDIA_JUMP_TO_TERRAIN:
+		parseTerrainHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_PEDIA_JUMP_TO_FEATURE:
+		parseFeatureHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_PEDIA_DESCRIPTION:
+		parseDescriptionHelp(widgetDataStruct, szBuffer, false);
+		break;
+
+	case WIDGET_CLOSE_SCREEN:
+		//parseCloseScreenHelp(szBuffer);
+		break;
+
+	case WIDGET_DEAL_KILL:
+		parseKillDealHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_PEDIA_DESCRIPTION_NO_HELP:
+		//parseDescriptionHelp(widgetDataStruct, szBuffer, true);
+		break;
+
+	case WIDGET_MINIMAP_HIGHLIGHT:
+		break;
+
+	case WIDGET_PRODUCTION_MOD_HELP:
+		parseProductionModHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_LEADERHEAD:
+		parseLeaderheadHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_LEADER_LINE:
+		parseLeaderLineHelp(widgetDataStruct, szBuffer);
+		break;
+
+	case WIDGET_COMMERCE_MOD_HELP:
+		parseCommerceModHelp(widgetDataStruct, szBuffer);
+		break;
+
+	}
+}
+
+// Protected Functions...
+bool CvDLLWidgetData::executeAction( CvWidgetDataStruct &widgetDataStruct )
+{
+	bool bHandled = false;			//	Right now general bHandled = false;  We can specific case this to true later.  Game will run with this = false;
+
+	switch (widgetDataStruct.m_eWidgetType)
+	{
+
+	case WIDGET_PLOT_LIST:
+		doPlotList(widgetDataStruct);
+		break;
+
+	case WIDGET_PLOT_LIST_SHIFT:
+		gDLL->getInterfaceIFace()->changePlotListColumn(widgetDataStruct.m_iData1 * ((gDLL->ctrlKey()) ? (GC.getDefineINT("MAX_PLOT_LIST_SIZE") - 1) : 1));
+		break;
+
+	case WIDGET_CITY_SCROLL:
+		if ( widgetDataStruct.m_iData1 > 0 )
+		{
+			GC.getGameINLINE().doControl(CONTROL_NEXTCITY);
+		}
+		else
+		{
+			GC.getGameINLINE().doControl(CONTROL_PREVCITY);
+		}
+		break;
+
+	case WIDGET_LIBERATE_CITY:
+		doLiberateCity();
+		break;
+
+	case WIDGET_CITY_NAME:
+		doRenameCity();
+		break;
+
+	case WIDGET_UNIT_NAME:
+		doRenameUnit();
+		break;
+
+	case WIDGET_CREATE_GROUP:
+		doCreateGroup();
+		break;
+
+	case WIDGET_DELETE_GROUP:
+		doDeleteGroup();
+		break;
+
+	case WIDGET_TRAIN:
+		doTrain(widgetDataStruct);
+		break;
+
+	case WIDGET_CONSTRUCT:
+		doConstruct(widgetDataStruct);
+		break;
+
+	case WIDGET_CREATE:
+		doCreate(widgetDataStruct);
+		break;
+
+	case WIDGET_MAINTAIN:
+		doMaintain(widgetDataStruct);
+		break;
+
+	case WIDGET_HURRY:
+		doHurry(widgetDataStruct);
+		break;
+
+	case WIDGET_MENU_ICON:
+		doMenu();
+
+	case WIDGET_CONSCRIPT:
+		doConscript();
+		break;
+
+	case WIDGET_ACTION:
+		doAction(widgetDataStruct);
+		break;
+
+	case WIDGET_CITIZEN:
+		break;
+
+	case WIDGET_FREE_CITIZEN:
+		break;
+
+	case WIDGET_DISABLED_CITIZEN:
+		break;
+
+	case WIDGET_ANGRY_CITIZEN:
+		break;
+
+	case WIDGET_CHANGE_SPECIALIST:
+		doChangeSpecialist(widgetDataStruct);
+		break;
+
+	case WIDGET_RESEARCH:
+	case WIDGET_TECH_TREE:
+		doResearch(widgetDataStruct);
+		break;
+
+	case WIDGET_CHANGE_PERCENT:
+		doChangePercent(widgetDataStruct);
+		break;
+
+	case WIDGET_CITY_TAB:
+		doCityTab(widgetDataStruct);
+		break;
+
+	case WIDGET_CONTACT_CIV:
+		doContactCiv(widgetDataStruct);
+		break;
+
+	case WIDGET_END_TURN:
+		GC.getGameINLINE().doControl(CONTROL_FORCEENDTURN);
+		break;
+
+	case WIDGET_LAUNCH_VICTORY:
+		doLaunch(widgetDataStruct);
+		break;
+
+	case WIDGET_CONVERT:
+		doConvert(widgetDataStruct);
+		break;
+
+	case WIDGET_REVOLUTION:
+		// handled in Python
+		break;
+
+	case WIDGET_AUTOMATE_CITIZENS:
+		doAutomateCitizens();
+		break;
+
+	case WIDGET_AUTOMATE_PRODUCTION:
+		doAutomateProduction();
+		break;
+
+	case WIDGET_EMPHASIZE:
+		doEmphasize(widgetDataStruct);
+		break;
+
+	case WIDGET_DIPLOMACY_RESPONSE:
+		// CLEANUP -- PD
+//		GC.getDiplomacyScreen().handleClick(m_pWidget);
+		break;
+
+	case WIDGET_TRADE_ITEM:
+		break;
+
+	case WIDGET_UNIT_MODEL:
+		doUnitModel();
+		break;
+
+	case WIDGET_FLAG:
+		doFlag();
+		break;
+
+	case WIDGET_HELP_SELECTED:
+		doSelected(widgetDataStruct);
+		break;
+
+	case WIDGET_PEDIA_JUMP_TO_UNIT:
+		doPediaUnitJump(widgetDataStruct);
+		break;
+
+	case WIDGET_PEDIA_JUMP_TO_BUILDING:
+		doPediaBuildingJump(widgetDataStruct);
+		break;
+
+	case WIDGET_PEDIA_JUMP_TO_TECH:
+	case WIDGET_PEDIA_JUMP_TO_REQUIRED_TECH:
+	case WIDGET_PEDIA_JUMP_TO_DERIVED_TECH:
+		doPediaTechJump(widgetDataStruct);
+		break;
+
+	case WIDGET_PEDIA_BACK:
+		doPediaBack();
+		break;
+	case WIDGET_PEDIA_FORWARD:
+		doPediaForward();
+		break;
+
+	case WIDGET_PEDIA_JUMP_TO_BONUS:
+		doPediaBonusJump(widgetDataStruct);
+		break;
+
+	case WIDGET_PEDIA_MAIN:
+		doPediaMain(widgetDataStruct);
+		break;
+
+	case WIDGET_PEDIA_JUMP_TO_PROMOTION:
+		doPediaPromotionJump(widgetDataStruct);
+		break;
+
+	case WIDGET_PEDIA_JUMP_TO_UNIT_COMBAT:
+		doPediaUnitCombatJump(widgetDataStruct);
+		break;
+
+	case WIDGET_PEDIA_JUMP_TO_IMPROVEMENT:
+		doPediaImprovementJump(widgetDataStruct);
+		break;
+
+	case WIDGET_PEDIA_JUMP_TO_CIVIC:
+		doPediaCivicJump(widgetDataStruct);
+		break;
+
+	case WIDGET_PEDIA_JUMP_TO_CIV:
+		doPediaCivilizationJump(widgetDataStruct);
+		break;
+
+	case WIDGET_PEDIA_JUMP_TO_LEADER:
+		doPediaLeaderJump(widgetDataStruct);
+		break;
+
+	case WIDGET_PEDIA_JUMP_TO_SPECIALIST:
+		doPediaSpecialistJump(widgetDataStruct);
+		break;
+
+	case WIDGET_PEDIA_JUMP_TO_PROJECT:
+		doPediaProjectJump(widgetDataStruct);
+		break;
+
+	case WIDGET_PEDIA_JUMP_TO_RELIGION:
+		doPediaReligionJump(widgetDataStruct);
+		break;
+
+	case WIDGET_PEDIA_JUMP_TO_CORPORATION:
+		doPediaCorporationJump(widgetDataStruct);
+		break;
+
+	case WIDGET_PEDIA_JUMP_TO_TERRAIN:
+		doPediaTerrainJump(widgetDataStruct);
+		break;
+
+	case WIDGET_PEDIA_JUMP_TO_FEATURE:
+		doPediaFeatureJump(widgetDataStruct);
+		break;
+
+	case WIDGET_PEDIA_DESCRIPTION:
+	case WIDGET_PEDIA_DESCRIPTION_NO_HELP:
+		doPediaDescription(widgetDataStruct);
+		break;
+
+	case WIDGET_TURN_EVENT:
+		doGotoTurnEvent(widgetDataStruct);
+		break;
+
+	case WIDGET_FOREIGN_ADVISOR:
+		doForeignAdvisor(widgetDataStruct);
+		break;
+
+	case WIDGET_DEAL_KILL:
+		doDealKill(widgetDataStruct);
+		break;
+
+	case WIDGET_MINIMAP_HIGHLIGHT:
+		doRefreshMilitaryAdvisor(widgetDataStruct);
+		break;
+
+	case WIDGET_CHOOSE_EVENT:
+		break;
+
+	case WIDGET_ZOOM_CITY:
+		break;
+
+	case WIDGET_HELP_TECH_PREPREQ:
+	case WIDGET_HELP_OBSOLETE:
+	case WIDGET_HELP_OBSOLETE_BONUS:
+	case WIDGET_HELP_OBSOLETE_SPECIAL:
+	case WIDGET_HELP_MOVE_BONUS:
+	case WIDGET_HELP_FREE_UNIT:
+	case WIDGET_HELP_FEATURE_PRODUCTION:
+	case WIDGET_HELP_WORKER_RATE:
+	case WIDGET_HELP_TRADE_ROUTES:
+	case WIDGET_HELP_HEALTH_RATE:
+	case WIDGET_HELP_HAPPINESS_RATE:
+	case WIDGET_HELP_FREE_TECH:
+	case WIDGET_HELP_LOS_BONUS:
+	case WIDGET_HELP_MAP_CENTER:
+	case WIDGET_HELP_MAP_REVEAL:
+	case WIDGET_HELP_MAP_TRADE:
+	case WIDGET_HELP_TECH_TRADE:
+	case WIDGET_HELP_GOLD_TRADE:
+	case WIDGET_HELP_OPEN_BORDERS:
+	case WIDGET_HELP_DEFENSIVE_PACT:
+	case WIDGET_HELP_PERMANENT_ALLIANCE:
+	case WIDGET_HELP_VASSAL_STATE:
+	case WIDGET_HELP_BUILD_BRIDGE:
+	case WIDGET_HELP_IRRIGATION:
+	case WIDGET_HELP_IGNORE_IRRIGATION:
+	case WIDGET_HELP_WATER_WORK:
+	case WIDGET_HELP_IMPROVEMENT:
+	case WIDGET_HELP_DOMAIN_EXTRA_MOVES:
+	case WIDGET_HELP_ADJUST:
+	case WIDGET_HELP_TERRAIN_TRADE:
+	case WIDGET_HELP_SPECIAL_BUILDING:
+	case WIDGET_HELP_YIELD_CHANGE:
+	case WIDGET_HELP_BONUS_REVEAL:
+	case WIDGET_HELP_CIVIC_REVEAL:
+	case WIDGET_HELP_PROCESS_INFO:
+	case WIDGET_HELP_FINANCE_NUM_UNITS:
+	case WIDGET_HELP_FINANCE_UNIT_COST:
+	case WIDGET_HELP_FINANCE_AWAY_SUPPLY:
+	case WIDGET_HELP_FINANCE_CITY_MAINT:
+	case WIDGET_HELP_FINANCE_CIVIC_UPKEEP:
+	case WIDGET_HELP_FINANCE_FOREIGN_INCOME:
+	case WIDGET_HELP_FINANCE_INFLATED_COSTS:
+	case WIDGET_HELP_FINANCE_GROSS_INCOME:
+	case WIDGET_HELP_FINANCE_NET_GOLD:
+	case WIDGET_HELP_FINANCE_GOLD_RESERVE:
+	case WIDGET_HELP_RELIGION_CITY:
+	case WIDGET_HELP_CORPORATION_CITY:
+	case WIDGET_HELP_PROMOTION:
+	case WIDGET_LEADERHEAD:
+	case WIDGET_LEADER_LINE:
+	case WIDGET_CLOSE_SCREEN:
+	case WIDGET_SCORE_BREAKDOWN:
+		//	Nothing on clicked
+		break;
+	}
+
+	return bHandled;
+}
+
+//	right clicking action
+bool CvDLLWidgetData::executeAltAction( CvWidgetDataStruct &widgetDataStruct )
+{
+	CvWidgetDataStruct widgetData = widgetDataStruct;
+
+	bool bHandled = true;
+	switch (widgetDataStruct.m_eWidgetType)
+	{
+	case WIDGET_HELP_TECH_ENTRY:
+	case WIDGET_HELP_TECH_PREPREQ:
+	case WIDGET_RESEARCH:
+	case WIDGET_TECH_TREE:
+		doPediaTechJump(widgetDataStruct);
+		break;
+	case WIDGET_TRAIN:
+		doPediaTrainJump(widgetDataStruct);
+		break;
+	case WIDGET_CONSTRUCT:
+		doPediaConstructJump(widgetDataStruct);
+		break;
+	case WIDGET_CREATE:
+		doPediaProjectJump(widgetDataStruct);
+		break;
+	case WIDGET_PEDIA_JUMP_TO_UNIT:
+	case WIDGET_HELP_FREE_UNIT:
+		doPediaUnitJump(widgetDataStruct);
+		break;
+	case WIDGET_HELP_FOUND_RELIGION:
+		widgetData.m_iData1 = widgetData.m_iData2;
+		//	Intentional fallthrough...
+	case WIDGET_PEDIA_JUMP_TO_RELIGION:
+		doPediaReligionJump(widgetData);
+		break;
+	case WIDGET_HELP_FOUND_CORPORATION:
+		widgetData.m_iData1 = widgetData.m_iData2;
+		//	Intentional fallthrough...
+	case WIDGET_PEDIA_JUMP_TO_CORPORATION:
+		doPediaCorporationJump(widgetData);
+		break;
+	case WIDGET_PEDIA_JUMP_TO_BUILDING:
+		doPediaBuildingJump(widgetDataStruct);
+		break;
+	case WIDGET_PEDIA_JUMP_TO_PROMOTION:
+		doPediaPromotionJump(widgetDataStruct);
+		break;
+	case WIDGET_HELP_OBSOLETE:
+		doPediaBuildingJump(widgetDataStruct);
+		break;
+	case WIDGET_HELP_IMPROVEMENT:
+		doPediaBuildJump(widgetDataStruct);
+		break;
+	case WIDGET_HELP_YIELD_CHANGE:
+		doPediaImprovementJump(widgetDataStruct, true);
+		break;
+	case WIDGET_HELP_BONUS_REVEAL:
+	case WIDGET_HELP_OBSOLETE_BONUS:
+		doPediaBonusJump(widgetDataStruct, true);
+		break;
+	case WIDGET_CITIZEN:
+	case WIDGET_FREE_CITIZEN:
+	case WIDGET_DISABLED_CITIZEN:
+		doPediaSpecialistJump(widgetDataStruct);
+		break;
+	case WIDGET_PEDIA_JUMP_TO_PROJECT:
+		doPediaProjectJump(widgetDataStruct);
+		break;
+	case WIDGET_HELP_CIVIC_REVEAL:
+		widgetData.m_iData1 = widgetData.m_iData2;
+		doPediaCivicJump(widgetData);
+		break;
+	case WIDGET_LEADERHEAD:
+		doContactCiv(widgetDataStruct);
+		break;
+
+	default:
+		bHandled = false;
+		break;
+	}
+
+	return (bHandled);
+}
+
+bool CvDLLWidgetData::isLink(const CvWidgetDataStruct &widgetDataStruct) const
+{
+	bool bLink = false;
+	switch (widgetDataStruct.m_eWidgetType)
+	{
+	case WIDGET_PEDIA_JUMP_TO_TECH:
+	case WIDGET_PEDIA_JUMP_TO_REQUIRED_TECH:
+	case WIDGET_PEDIA_JUMP_TO_DERIVED_TECH:
+	case WIDGET_PEDIA_JUMP_TO_BUILDING:
+	case WIDGET_PEDIA_JUMP_TO_UNIT:
+	case WIDGET_PEDIA_JUMP_TO_UNIT_COMBAT:
+	case WIDGET_PEDIA_JUMP_TO_PROMOTION:
+	case WIDGET_PEDIA_JUMP_TO_BONUS:
+	case WIDGET_PEDIA_JUMP_TO_IMPROVEMENT:
+	case WIDGET_PEDIA_JUMP_TO_CIVIC:
+	case WIDGET_PEDIA_JUMP_TO_CIV:
+	case WIDGET_PEDIA_JUMP_TO_LEADER:
+	case WIDGET_PEDIA_JUMP_TO_SPECIALIST:
+	case WIDGET_PEDIA_JUMP_TO_PROJECT:
+	case WIDGET_PEDIA_JUMP_TO_RELIGION:
+	case WIDGET_PEDIA_JUMP_TO_CORPORATION:
+	case WIDGET_PEDIA_JUMP_TO_TERRAIN:
+	case WIDGET_PEDIA_JUMP_TO_FEATURE:
+	case WIDGET_PEDIA_FORWARD:
+	case WIDGET_PEDIA_BACK:
+	case WIDGET_PEDIA_MAIN:
+	case WIDGET_TURN_EVENT:
+	case WIDGET_FOREIGN_ADVISOR:
+	case WIDGET_PEDIA_DESCRIPTION:
+	case WIDGET_PEDIA_DESCRIPTION_NO_HELP:
+	case WIDGET_MINIMAP_HIGHLIGHT:
+		bLink = (widgetDataStruct.m_iData1 >= 0);
+		break;
+	case WIDGET_DEAL_KILL:
+		{
+			CvDeal* pDeal = GC.getGameINLINE().getDeal(widgetDataStruct.m_iData1);
+			bLink = (NULL != pDeal && pDeal->isCancelable(GC.getGameINLINE().getActivePlayer()));
+		}
+		break;
+	case WIDGET_CONVERT:
+		bLink = (0 != widgetDataStruct.m_iData2);
+		break;
+	case WIDGET_GENERAL:
+	case WIDGET_REVOLUTION:
+		bLink = (1 == widgetDataStruct.m_iData1);
+		break;
+	}
+	return (bLink);
+}
+
+
+void CvDLLWidgetData::doPlotList(CvWidgetDataStruct &widgetDataStruct)
+{
+	PROFILE_FUNC();
+
+	CvUnit* pUnit;
+	bool bWasCityScreenUp;
+
+	int iUnitIndex = widgetDataStruct.m_iData1 + gDLL->getInterfaceIFace()->getPlotListColumn() - gDLL->getInterfaceIFace()->getPlotListOffset();
+
+	CvPlot *selectionPlot = gDLL->getInterfaceIFace()->getSelectionPlot();
+	pUnit = gDLL->getInterfaceIFace()->getInterfacePlotUnit(selectionPlot, iUnitIndex);
+
+	if (pUnit != NULL)
+	{
+		if (pUnit->getOwnerINLINE() == GC.getGameINLINE().getActivePlayer())
+		{
+			bWasCityScreenUp = gDLL->getInterfaceIFace()->isCityScreenUp();
+
+			gDLL->getInterfaceIFace()->selectGroup(pUnit, gDLL->shiftKey(), gDLL->ctrlKey(), gDLL->altKey());
+
+			if (bWasCityScreenUp)
+			{
+				gDLL->getInterfaceIFace()->lookAtSelectionPlot();
+			}
+		}
+	}
+}
+
+
+void CvDLLWidgetData::doLiberateCity()
+{
+	GC.getGameINLINE().selectedCitiesGameNetMessage(GAMEMESSAGE_DO_TASK, TASK_LIBERATE, 0);
+
+	gDLL->getInterfaceIFace()->clearSelectedCities();
+}
+
+
+void CvDLLWidgetData::doRenameCity()
+{
+	CvCity* pHeadSelectedCity;
+
+	pHeadSelectedCity = gDLL->getInterfaceIFace()->getHeadSelectedCity();
+
+	if (pHeadSelectedCity != NULL)
+	{
+		if (pHeadSelectedCity->getOwnerINLINE() == GC.getGameINLINE().getActivePlayer())
+		{
+			CvEventReporter::getInstance().cityRename(pHeadSelectedCity);
+		}
+	}
+}
+
+
+void CvDLLWidgetData::doRenameUnit()
+{
+	CvUnit* pHeadSelectedUnit;
+
+	pHeadSelectedUnit = gDLL->getInterfaceIFace()->getHeadSelectedUnit();
+
+	if (pHeadSelectedUnit != NULL)
+	{
+		if (pHeadSelectedUnit->getOwnerINLINE() == GC.getGameINLINE().getActivePlayer())
+		{
+			CvEventReporter::getInstance().unitRename(pHeadSelectedUnit);
+		}
+	}
+}
+
+
+void CvDLLWidgetData::doCreateGroup()
+{
+	GC.getGameINLINE().selectionListGameNetMessage(GAMEMESSAGE_JOIN_GROUP);
+}
+
+
+void CvDLLWidgetData::doDeleteGroup()
+{
+	GC.getGameINLINE().selectionListGameNetMessage(GAMEMESSAGE_JOIN_GROUP, -1, -1, -1, 0, false, true);
+}
+
+
+void CvDLLWidgetData::doTrain(CvWidgetDataStruct &widgetDataStruct)
+{
+	UnitTypes eUnit;
+
+	eUnit = ((UnitTypes)(GC.getCivilizationInfo(GC.getGameINLINE().getActiveCivilizationType()).getCivilizationUnits(widgetDataStruct.m_iData1)));
+
+	if (widgetDataStruct.m_iData2 != FFreeList::INVALID_INDEX)
+	{
+		CvMessageControl::getInstance().sendPushOrder(widgetDataStruct.m_iData2, ORDER_TRAIN, eUnit, false, false, false);
+	}
+	else
+	{
+		GC.getGameINLINE().selectedCitiesGameNetMessage(GAMEMESSAGE_PUSH_ORDER, ORDER_TRAIN, eUnit, -1, false, gDLL->altKey(), gDLL->shiftKey(), gDLL->ctrlKey());
+	}
+
+	gDLL->getInterfaceIFace()->setCityTabSelectionRow(CITYTAB_UNITS);
+}
+
+
+void CvDLLWidgetData::doConstruct(CvWidgetDataStruct &widgetDataStruct)
+{
+	BuildingTypes eBuilding;
+
+	eBuilding = ((BuildingTypes)(GC.getCivilizationInfo(GC.getGameINLINE().getActiveCivilizationType()).getCivilizationBuildings(widgetDataStruct.m_iData1)));
+
+	if (widgetDataStruct.m_iData2 != FFreeList::INVALID_INDEX)
+	{
+		CvMessageControl::getInstance().sendPushOrder(widgetDataStruct.m_iData2, ORDER_CONSTRUCT, eBuilding, false, false, false);
+	}
+	else
+	{
+		GC.getGameINLINE().selectedCitiesGameNetMessage(GAMEMESSAGE_PUSH_ORDER, ORDER_CONSTRUCT, eBuilding, -1, false, gDLL->altKey(), gDLL->shiftKey(), gDLL->ctrlKey());
+	}
+
+	if (isLimitedWonderClass((BuildingClassTypes)(widgetDataStruct.m_iData1)))
+	{
+		gDLL->getInterfaceIFace()->setCityTabSelectionRow(CITYTAB_WONDERS);
+	}
+	else
+	{
+		gDLL->getInterfaceIFace()->setCityTabSelectionRow(CITYTAB_BUILDINGS);
+	}
+}
+
+
+void CvDLLWidgetData::doCreate(CvWidgetDataStruct &widgetDataStruct)
+{
+	if (widgetDataStruct.m_iData2 != FFreeList::INVALID_INDEX)
+	{
+		CvMessageControl::getInstance().sendPushOrder(widgetDataStruct.m_iData2, ORDER_CREATE, widgetDataStruct.m_iData1, false, false, false);
+	}
+	else
+	{
+		GC.getGameINLINE().selectedCitiesGameNetMessage(GAMEMESSAGE_PUSH_ORDER, ORDER_CREATE, widgetDataStruct.m_iData1, -1, false, gDLL->altKey(), gDLL->shiftKey(), gDLL->ctrlKey());
+	}
+
+	gDLL->getInterfaceIFace()->setCityTabSelectionRow(CITYTAB_WONDERS);
+}
+
+
+void CvDLLWidgetData::doMaintain(CvWidgetDataStruct &widgetDataStruct)
+{
+	if (widgetDataStruct.m_iData2 != FFreeList::INVALID_INDEX)
+	{
+		CvMessageControl::getInstance().sendPushOrder(widgetDataStruct.m_iData2, ORDER_MAINTAIN, widgetDataStruct.m_iData1, false, false, false);
+	}
+	else
+	{
+		GC.getGameINLINE().selectedCitiesGameNetMessage(GAMEMESSAGE_PUSH_ORDER, ORDER_MAINTAIN, widgetDataStruct.m_iData1, -1, false, gDLL->altKey(), gDLL->shiftKey(), gDLL->ctrlKey());
+	}
+
+	gDLL->getInterfaceIFace()->setCityTabSelectionRow(CITYTAB_WONDERS);
+}
+
+
+void CvDLLWidgetData::doHurry(CvWidgetDataStruct &widgetDataStruct)
+{
+	GC.getGameINLINE().selectedCitiesGameNetMessage(GAMEMESSAGE_DO_TASK, TASK_HURRY, widgetDataStruct.m_iData1);
+}
+
+
+void CvDLLWidgetData::doConscript()
+{
+	GC.getGameINLINE().selectedCitiesGameNetMessage(GAMEMESSAGE_DO_TASK, TASK_CONSCRIPT);
+}
+
+
+void CvDLLWidgetData::doAction(CvWidgetDataStruct &widgetDataStruct)
+{
+	GC.getGameINLINE().handleAction(widgetDataStruct.m_iData1);
+}
+
+
+void CvDLLWidgetData::doChangeSpecialist(CvWidgetDataStruct &widgetDataStruct)
+{
+	GC.getGameINLINE().selectedCitiesGameNetMessage(GAMEMESSAGE_DO_TASK, TASK_CHANGE_SPECIALIST, widgetDataStruct.m_iData1, widgetDataStruct.m_iData2);
+}
+
+
+void CvDLLWidgetData::doResearch(CvWidgetDataStruct &widgetDataStruct)
+{
+	bool bShift;
+
+	bShift = gDLL->shiftKey();
+
+	if (!bShift)
+	{
+		if ((GetKeyState(VK_LSHIFT) & 0x8000) || (GetKeyState(VK_RSHIFT) & 0x8000))
+		{
+			bShift = true;
+		}
+	}
+
+	// RBMP Free Tech Popup Fix
+	if (widgetDataStruct.m_iData2 > 0)
+	{
+		CvPlayer& kPlayer = GET_PLAYER(GC.getGameINLINE().getActivePlayer());
+
+		if (!kPlayer.isChoosingFreeTech())
+		{
+			gDLL->getInterfaceIFace()->addMessage(GC.getGameINLINE().getActivePlayer(), true, GC.getEVENT_MESSAGE_TIME(), gDLL->getText("TXT_KEY_CHEATERS_NEVER_PROSPER"), NULL, MESSAGE_TYPE_MAJOR_EVENT);
+			return;
+		}
+		else
+		{
+			kPlayer.setChoosingFreeTech(false);
+		}
+	}
+
+	CvMessageControl::getInstance().sendResearch(((TechTypes)widgetDataStruct.m_iData1), widgetDataStruct.m_iData2, bShift);
+}
+
+
+void CvDLLWidgetData::doChangePercent(CvWidgetDataStruct &widgetDataStruct)
+{
+	CvMessageControl::getInstance().sendPercentChange(((CommerceTypes)widgetDataStruct.m_iData1), widgetDataStruct.m_iData2);
+}
+
+void CvDLLWidgetData::doCityTab(CvWidgetDataStruct &widgetDataStruct)
+{
+	gDLL->getInterfaceIFace()->setCityTabSelectionRow((CityTabTypes)widgetDataStruct.m_iData1);
+}
+
+void CvDLLWidgetData::doContactCiv(CvWidgetDataStruct &widgetDataStruct)
+{
+	if (gDLL->isDiplomacy() || gDLL->isMPDiplomacyScreenUp())
+	{
+		return;
+	}
+
+	//	Do not execute this if we are trying to contact ourselves...
+	if (GC.getGameINLINE().getActivePlayer() == widgetDataStruct.m_iData1)
+	{
+		if (!gDLL->getInterfaceIFace()->isFocusedWidget())
+		{
+			gDLL->getInterfaceIFace()->toggleScoresMinimized();
+		}
+
+		return;
+	}
+
+	if (gDLL->shiftKey())
+	{
+		if (GET_PLAYER((PlayerTypes)widgetDataStruct.m_iData1).isHuman())
+		{
+			if (widgetDataStruct.m_iData1 != GC.getGameINLINE().getActivePlayer())
+			{
+				gDLL->getInterfaceIFace()->showTurnLog((ChatTargetTypes)widgetDataStruct.m_iData1);
+			}
+		}
+		return;
+	}
+
+	if (gDLL->altKey())
+	{
+		if (GET_TEAM(GC.getGameINLINE().getActiveTeam()).canDeclareWar(GET_PLAYER((PlayerTypes)widgetDataStruct.m_iData1).getTeam()))
+		{
+			CvMessageControl::getInstance().sendChangeWar(GET_PLAYER((PlayerTypes)widgetDataStruct.m_iData1).getTeam(), true);
+		}
+		else if (GET_TEAM(GET_PLAYER((PlayerTypes)widgetDataStruct.m_iData1).getTeam()).isVassal(GC.getGameINLINE().getActiveTeam()))
+		{
+			CvPopupInfo* pInfo = new CvPopupInfo(BUTTONPOPUP_VASSAL_DEMAND_TRIBUTE, widgetDataStruct.m_iData1);
+			if (pInfo)
+			{
+				gDLL->getInterfaceIFace()->addPopup(pInfo, GC.getGameINLINE().getActivePlayer(), true);
+			}
+		}
+		return;
+	}
+
+	GET_PLAYER(GC.getGameINLINE().getActivePlayer()).contact((PlayerTypes)widgetDataStruct.m_iData1);
+}
+
+void CvDLLWidgetData::doConvert(CvWidgetDataStruct &widgetDataStruct)
+{
+	if (widgetDataStruct.m_iData2 != 0)
+	{
+		CvMessageControl::getInstance().sendConvert((ReligionTypes)(widgetDataStruct.m_iData1));
+	}
+}
+
+void CvDLLWidgetData::doAutomateCitizens()
+{
+	CvCity* pHeadSelectedCity;
+
+	pHeadSelectedCity = gDLL->getInterfaceIFace()->getHeadSelectedCity();
+
+	if (pHeadSelectedCity != NULL)
+	{
+		GC.getGameINLINE().selectedCitiesGameNetMessage(GAMEMESSAGE_DO_TASK, TASK_SET_AUTOMATED_CITIZENS, -1, -1, !(pHeadSelectedCity->isCitizensAutomated()));
+	}
+}
+
+void CvDLLWidgetData::doAutomateProduction()
+{
+	CvCity* pHeadSelectedCity;
+
+	pHeadSelectedCity = gDLL->getInterfaceIFace()->getHeadSelectedCity();
+
+	if (pHeadSelectedCity != NULL)
+	{
+		GC.getGameINLINE().selectedCitiesGameNetMessage(GAMEMESSAGE_DO_TASK, TASK_SET_AUTOMATED_PRODUCTION, -1, -1, !pHeadSelectedCity->isProductionAutomated(), gDLL->altKey(), gDLL->shiftKey(), gDLL->ctrlKey());
+	}
+}
+
+void CvDLLWidgetData::doEmphasize(CvWidgetDataStruct &widgetDataStruct)
+{
+	CvCity* pHeadSelectedCity;
+
+	pHeadSelectedCity = gDLL->getInterfaceIFace()->getHeadSelectedCity();
+
+	if (pHeadSelectedCity != NULL)
+	{
+		GC.getGameINLINE().selectedCitiesGameNetMessage(GAMEMESSAGE_DO_TASK, TASK_SET_EMPHASIZE, widgetDataStruct.m_iData1, -1, !(pHeadSelectedCity->AI_isEmphasize((EmphasizeTypes)(widgetDataStruct.m_iData1))));
+	}
+}
+
+void CvDLLWidgetData::doUnitModel()
+{
+	if (gDLL->getInterfaceIFace()->isFocused())
+	{
+		//	Do NOT execute if a screen is up...
+		return;
+	}
+
+	gDLL->getInterfaceIFace()->lookAtSelectionPlot();
+}
+
+
+void CvDLLWidgetData::doFlag()
+{
+	GC.getGameINLINE().doControl(CONTROL_SELECTCAPITAL);
+}
+
+void CvDLLWidgetData::doSelected(CvWidgetDataStruct &widgetDataStruct)
+{
+	CvCity* pHeadSelectedCity;
+
+	pHeadSelectedCity = gDLL->getInterfaceIFace()->getHeadSelectedCity();
+
+	if (pHeadSelectedCity != NULL)
+	{
+		GC.getGameINLINE().selectedCitiesGameNetMessage(GAMEMESSAGE_POP_ORDER, widgetDataStruct.m_iData1);
+	}
+}
+
+
+void CvDLLWidgetData::doPediaTechJump(CvWidgetDataStruct &widgetDataStruct)
+{
+	CyArgsList argsList;
+	argsList.add(widgetDataStruct.m_iData1);
+	gDLL->getPythonIFace()->callFunction(PYScreensModule, "pediaJumpToTech", argsList.makeFunctionArgs());
+}
+
+void CvDLLWidgetData::doPediaUnitJump(CvWidgetDataStruct &widgetDataStruct)
+{
+	CyArgsList argsList;
+
+	argsList.add(widgetDataStruct.m_iData1);
+	gDLL->getPythonIFace()->callFunction(PYScreensModule, "pediaJumpToUnit", argsList.makeFunctionArgs());
+}
+
+void CvDLLWidgetData::doPediaBuildingJump(CvWidgetDataStruct &widgetDataStruct)
+{
+	CyArgsList argsList;
+	argsList.add(widgetDataStruct.m_iData1);
+	gDLL->getPythonIFace()->callFunction(PYScreensModule, "pediaJumpToBuilding", argsList.makeFunctionArgs());
+}
+
+void CvDLLWidgetData::doPediaProjectJump(CvWidgetDataStruct &widgetDataStruct)
+{
+	CyArgsList argsList;
+	argsList.add(widgetDataStruct.m_iData1);
+	gDLL->getPythonIFace()->callFunction(PYScreensModule, "pediaJumpToProject", argsList.makeFunctionArgs());
+}
+
+void CvDLLWidgetData::doPediaReligionJump(CvWidgetDataStruct &widgetDataStruct)
+{
+	CyArgsList argsList;
+	argsList.add(widgetDataStruct.m_iData1);
+	gDLL->getPythonIFace()->callFunction(PYScreensModule, "pediaJumpToReligion", argsList.makeFunctionArgs());
+}
+
+void CvDLLWidgetData::doPediaCorporationJump(CvWidgetDataStruct &widgetDataStruct)
+{
+	CyArgsList argsList;
+	argsList.add(widgetDataStruct.m_iData1);
+	gDLL->getPythonIFace()->callFunction(PYScreensModule, "pediaJumpToCorporation", argsList.makeFunctionArgs());
+}
+
+void CvDLLWidgetData::doPediaTerrainJump(CvWidgetDataStruct &widgetDataStruct)
+{
+	CyArgsList argsList;
+	argsList.add(widgetDataStruct.m_iData1);
+	gDLL->getPythonIFace()->callFunction(PYScreensModule, "pediaJumpToTerrain", argsList.makeFunctionArgs());
+}
+
+void CvDLLWidgetData::doPediaFeatureJump(CvWidgetDataStruct &widgetDataStruct)
+{
+	CyArgsList argsList;
+	argsList.add(widgetDataStruct.m_iData1);
+	gDLL->getPythonIFace()->callFunction(PYScreensModule, "pediaJumpToFeature", argsList.makeFunctionArgs());
+}
+
+void CvDLLWidgetData::doPediaTrainJump(CvWidgetDataStruct &widgetDataStruct)
+{
+	CyArgsList argsList;
+	argsList.add(GC.getCivilizationInfo(GC.getGameINLINE().getActiveCivilizationType()).getCivilizationUnits(widgetDataStruct.m_iData1));
+	
+	gDLL->getPythonIFace()->callFunction(PYScreensModule, "pediaJumpToUnit", argsList.makeFunctionArgs());
+}
+
+
+void CvDLLWidgetData::doPediaConstructJump(CvWidgetDataStruct &widgetDataStruct)
+{
+	CyArgsList argsList;
+	argsList.add(GC.getCivilizationInfo(GC.getGameINLINE().getActiveCivilizationType()).getCivilizationBuildings(widgetDataStruct.m_iData1));
+
+	gDLL->getPythonIFace()->callFunction(PYScreensModule, "pediaJumpToBuilding", argsList.makeFunctionArgs());
+}
+
+
+void CvDLLWidgetData::doPediaBack()
+{
+	gDLL->getPythonIFace()->callFunction(PYScreensModule, "pediaBack");	
+}
+
+void CvDLLWidgetData::doPediaForward()
+{
+	gDLL->getPythonIFace()->callFunction(PYScreensModule, "pediaForward");	
+}
+
+void CvDLLWidgetData::doPediaBonusJump(CvWidgetDataStruct &widgetDataStruct, bool bData2)
+{
+	CyArgsList argsList;
+	if (bData2)
+	{
+		argsList.add(widgetDataStruct.m_iData2);
+	}
+	else
+	{
+		argsList.add(widgetDataStruct.m_iData1);
+	}
+	gDLL->getPythonIFace()->callFunction(PYScreensModule, "pediaJumpToBonus", argsList.makeFunctionArgs());	
+}
+
+void CvDLLWidgetData::doPediaSpecialistJump(CvWidgetDataStruct &widgetDataStruct)
+{
+	CyArgsList argsList;
+	argsList.add(widgetDataStruct.m_iData1);
+	gDLL->getPythonIFace()->callFunction(PYScreensModule, "pediaJumpToSpecialist", argsList.makeFunctionArgs());	
+}
+
+void CvDLLWidgetData::doPediaMain(CvWidgetDataStruct &widgetDataStruct)
+{
+	CyArgsList argsList;
+	argsList.add(widgetDataStruct.m_iData1 < 0 ? 0 : widgetDataStruct.m_iData1);
+	gDLL->getPythonIFace()->callFunction(PYScreensModule, "pediaMain", argsList.makeFunctionArgs());	
+}
+
+void CvDLLWidgetData::doPediaPromotionJump(CvWidgetDataStruct &widgetDataStruct)
+{
+	CyArgsList argsList;
+	argsList.add(widgetDataStruct.m_iData1);
+	gDLL->getPythonIFace()->callFunction(PYScreensModule, "pediaJumpToPromotion", argsList.makeFunctionArgs());
+}
+
+void CvDLLWidgetData::doPediaUnitCombatJump(CvWidgetDataStruct &widgetDataStruct)
+{
+	CyArgsList argsList;
+	argsList.add(widgetDataStruct.m_iData1);
+	gDLL->getPythonIFace()->callFunction(PYScreensModule, "pediaJumpToUnitChart", argsList.makeFunctionArgs());
+}
+
+void CvDLLWidgetData::doPediaImprovementJump(CvWidgetDataStruct &widgetDataStruct, bool bData2)
+{
+	CyArgsList argsList;
+	if (bData2)
+	{
+		argsList.add(widgetDataStruct.m_iData2);
+	}
+	else
+	{
+		argsList.add(widgetDataStruct.m_iData1);
+	}
+	gDLL->getPythonIFace()->callFunction(PYScreensModule, "pediaJumpToImprovement", argsList.makeFunctionArgs());
+}
+
+void CvDLLWidgetData::doPediaCivicJump(CvWidgetDataStruct &widgetDataStruct)
+{
+	CyArgsList argsList;
+	argsList.add(widgetDataStruct.m_iData1);
+	gDLL->getPythonIFace()->callFunction(PYScreensModule, "pediaJumpToCivic", argsList.makeFunctionArgs());
+}
+
+void CvDLLWidgetData::doPediaCivilizationJump(CvWidgetDataStruct &widgetDataStruct)
+{
+	CyArgsList argsList;
+	argsList.add(widgetDataStruct.m_iData1);
+	gDLL->getPythonIFace()->callFunction(PYScreensModule, "pediaJumpToCiv", argsList.makeFunctionArgs());
+}
+
+void CvDLLWidgetData::doPediaLeaderJump(CvWidgetDataStruct &widgetDataStruct)
+{
+	CyArgsList argsList;
+	argsList.add(widgetDataStruct.m_iData1);
+	gDLL->getPythonIFace()->callFunction(PYScreensModule, "pediaJumpToLeader", argsList.makeFunctionArgs());
+}
+
+void CvDLLWidgetData::doPediaDescription(CvWidgetDataStruct &widgetDataStruct)
+{
+	CyArgsList argsList;
+	argsList.add(widgetDataStruct.m_iData1);
+	argsList.add(widgetDataStruct.m_iData2);
+	gDLL->getPythonIFace()->callFunction(PYScreensModule, "pediaShowHistorical", argsList.makeFunctionArgs());
+}
+
+void CvDLLWidgetData::doPediaBuildJump(CvWidgetDataStruct &widgetDataStruct)
+{
+	CyArgsList argsList;
+
+	ImprovementTypes eImprovement = NO_IMPROVEMENT;
+	BuildTypes eBuild = (BuildTypes)widgetDataStruct.m_iData2;
+	if (NO_BUILD != eBuild)
+	{
+		eImprovement = (ImprovementTypes)GC.getBuildInfo(eBuild).getImprovement();
+	}
+
+	if (NO_IMPROVEMENT != eImprovement)
+	{
+		argsList.add(eImprovement);
+		gDLL->getPythonIFace()->callFunction(PYScreensModule, "pediaJumpToImprovement", argsList.makeFunctionArgs());
+	}
+}
+
+void CvDLLWidgetData::doGotoTurnEvent(CvWidgetDataStruct &widgetDataStruct)
+{
+	CvPlot* pPlot = GC.getMapINLINE().plotINLINE(widgetDataStruct.m_iData1, widgetDataStruct.m_iData2);
+
+	if (NULL != pPlot && !gDLL->getEngineIFace()->isCameraLocked())
+	{
+		if (pPlot->isRevealed(GC.getGameINLINE().getActiveTeam(), false))
+		{
+			gDLL->getEngineIFace()->cameraLookAt(pPlot->getPoint());
+		}
+	}
+}
+
+void CvDLLWidgetData::doMenu( void )
+{
+	if (!gDLL->isGameInitializing())
+	{
+		CvPopupInfo* pInfo = new CvPopupInfo(BUTTONPOPUP_MAIN_MENU);
+		if (NULL != pInfo)
+		{
+			gDLL->getInterfaceIFace()->addPopup(pInfo, NO_PLAYER, true);
+		}
+	}
+}
+
+void CvDLLWidgetData::doLaunch(CvWidgetDataStruct &widgetDataStruct)
+{
+	if (GET_TEAM(GC.getGameINLINE().getActiveTeam()).canLaunch((VictoryTypes)widgetDataStruct.m_iData1) && GC.getGameINLINE().testVictory((VictoryTypes)widgetDataStruct.m_iData1, GC.getGameINLINE().getActiveTeam()))
+	{
+		CvPopupInfo* pInfo = new CvPopupInfo(BUTTONPOPUP_LAUNCH, widgetDataStruct.m_iData1);
+		if (NULL != pInfo)
+		{
+			gDLL->getInterfaceIFace()->addPopup(pInfo);
+		}
+	}
+}
+
+void CvDLLWidgetData::doForeignAdvisor(CvWidgetDataStruct &widgetDataStruct)
+{
+	CyArgsList argsList;
+	argsList.add(widgetDataStruct.m_iData1);
+	gDLL->getPythonIFace()->callFunction(PYScreensModule, "showForeignAdvisorScreen", argsList.makeFunctionArgs());
+}
+
+//
+//	HELP PARSING FUNCTIONS
+//
+
+void CvDLLWidgetData::parsePlotListHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	PROFILE_FUNC();
+
+	CvUnit* pUnit;
+
+	int iUnitIndex = widgetDataStruct.m_iData1 + gDLL->getInterfaceIFace()->getPlotListColumn() - gDLL->getInterfaceIFace()->getPlotListOffset();
+
+	CvPlot *selectionPlot = gDLL->getInterfaceIFace()->getSelectionPlot();
+	pUnit = gDLL->getInterfaceIFace()->getInterfacePlotUnit(selectionPlot, iUnitIndex);
+
+	if (pUnit != NULL)
+	{
+		GAMETEXT.setUnitHelp(szBuffer, pUnit);
+
+		if (pUnit->plot()->plotCount(PUF_isUnitType, pUnit->getUnitType(), -1, pUnit->getOwnerINLINE()) > 1)
+		{
+			szBuffer.append(NEWLINE);
+			szBuffer.append(gDLL->getText("TXT_KEY_MISC_CTRL_SELECT", GC.getUnitInfo(pUnit->getUnitType()).getTextKeyWide()));
+		}
+
+		if (pUnit->plot()->plotCount(NULL, -1, -1, pUnit->getOwnerINLINE()) > 1)
+		{
+			szBuffer.append(NEWLINE);
+			szBuffer.append(gDLL->getText("TXT_KEY_MISC_ALT_SELECT"));
+		}
+	}
+}
+
+
+void CvDLLWidgetData::parseLiberateCityHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	CvCity* pHeadSelectedCity;
+	CvWString szTempBuffer;
+
+	pHeadSelectedCity = gDLL->getInterfaceIFace()->getHeadSelectedCity();
+
+	if (pHeadSelectedCity != NULL)
+	{
+		PlayerTypes ePlayer = pHeadSelectedCity->getLiberationPlayer(false);
+		if (NO_PLAYER != ePlayer)
+		{
+			szBuffer.append(gDLL->getText("TXT_KEY_LIBERATE_CITY_HELP", pHeadSelectedCity->getNameKey(), GET_PLAYER(ePlayer).getNameKey()));
+		}
+	}
+}
+
+void CvDLLWidgetData::parseCityNameHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	CvCity* pHeadSelectedCity;
+	CvWString szTempBuffer;
+
+	pHeadSelectedCity = gDLL->getInterfaceIFace()->getHeadSelectedCity();
+
+	if (pHeadSelectedCity != NULL)
+	{
+		szBuffer.append(pHeadSelectedCity->getName());
+
+		szBuffer.append(NEWLINE);
+		szBuffer.append(gDLL->getText("TXT_KEY_CITY_POPULATION", pHeadSelectedCity->getRealPopulation()));
+
+		GAMETEXT.setTimeStr(szTempBuffer, pHeadSelectedCity->getGameTurnFounded(), false);
+		szBuffer.append(NEWLINE);
+		szBuffer.append(gDLL->getText("TXT_KEY_CITY_FOUNDED", szTempBuffer.GetCString()));
+
+		szBuffer.append(NEWLINE);
+		szBuffer.append(gDLL->getText("TXT_KEY_CHANGE_NAME"));
+	}
+}
+
+
+
+void CvDLLWidgetData::parseTrainHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	CvCity* pHeadSelectedCity;
+	UnitTypes eUnit;
+
+	if (widgetDataStruct.m_iData2 != FFreeList::INVALID_INDEX)
+	{
+		pHeadSelectedCity = GET_PLAYER(GC.getGameINLINE().getActivePlayer()).getCity(widgetDataStruct.m_iData2);
+	}
+	else
+	{
+		pHeadSelectedCity = gDLL->getInterfaceIFace()->getHeadSelectedCity();
+	}
+
+	if (pHeadSelectedCity != NULL)
+	{
+		eUnit = (UnitTypes)GC.getCivilizationInfo(pHeadSelectedCity->getCivilizationType()).getCivilizationUnits(widgetDataStruct.m_iData1);
+
+		GAMETEXT.setUnitHelp(szBuffer, eUnit, false, widgetDataStruct.m_bOption, false, pHeadSelectedCity);
+	}
+}
+
+
+void CvDLLWidgetData::parseConstructHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	CvCity* pHeadSelectedCity;
+	BuildingTypes eBuilding;
+
+	if (widgetDataStruct.m_iData2 != FFreeList::INVALID_INDEX)
+	{
+		pHeadSelectedCity = GET_PLAYER(GC.getGameINLINE().getActivePlayer()).getCity(widgetDataStruct.m_iData2);
+	}
+	else
+	{
+		pHeadSelectedCity = gDLL->getInterfaceIFace()->getHeadSelectedCity();
+	}
+
+	if (pHeadSelectedCity != NULL)
+	{
+		eBuilding = (BuildingTypes)GC.getCivilizationInfo(pHeadSelectedCity->getCivilizationType()).getCivilizationBuildings(widgetDataStruct.m_iData1);
+
+		GAMETEXT.setBuildingHelp(szBuffer, eBuilding, false, widgetDataStruct.m_bOption, false, pHeadSelectedCity);
+	}
+}
+
+
+void CvDLLWidgetData::parseCreateHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	CvCity* pHeadSelectedCity;
+
+	if (widgetDataStruct.m_iData2 != FFreeList::INVALID_INDEX)
+	{
+		pHeadSelectedCity = GET_PLAYER(GC.getGameINLINE().getActivePlayer()).getCity(widgetDataStruct.m_iData2);
+	}
+	else
+	{
+		pHeadSelectedCity = gDLL->getInterfaceIFace()->getHeadSelectedCity();
+	}
+
+	GAMETEXT.setProjectHelp(szBuffer, ((ProjectTypes)widgetDataStruct.m_iData1), false, pHeadSelectedCity);
+}
+
+
+void CvDLLWidgetData::parseMaintainHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	GAMETEXT.setProcessHelp(szBuffer, ((ProcessTypes)(widgetDataStruct.m_iData1)));
+}
+
+
+void CvDLLWidgetData::parseHurryHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	CvCity* pHeadSelectedCity;
+	CvWString szTempBuffer;
+	bool bFirst;
+	int iHurryGold;
+	int iHurryPopulation;
+	int iHurryAngerLength;
+	int iI;
+
+	pHeadSelectedCity = gDLL->getInterfaceIFace()->getHeadSelectedCity();
+
+	if (pHeadSelectedCity != NULL)
+	{
+		szBuffer.assign(gDLL->getText("TXT_KEY_MISC_HURRY_PROD", pHeadSelectedCity->getProductionNameKey()));
+
+		iHurryGold = pHeadSelectedCity->hurryGold((HurryTypes)(widgetDataStruct.m_iData1));
+
+		if (iHurryGold > 0)
+		{
+			szBuffer.append(NEWLINE);
+			szBuffer.append(gDLL->getText("TXT_KEY_MISC_HURRY_GOLD", iHurryGold));
+		}
+
+		iHurryPopulation = pHeadSelectedCity->hurryPopulation((HurryTypes)(widgetDataStruct.m_iData1));
+
+		if (iHurryPopulation > 0)
+		{
+			szBuffer.append(NEWLINE);
+			szBuffer.append(gDLL->getText("TXT_KEY_MISC_HURRY_POP", iHurryPopulation));
+
+			if (iHurryPopulation > pHeadSelectedCity->maxHurryPopulation())
+			{
+				szBuffer.append(gDLL->getText("TXT_KEY_MISC_MAX_POP_HURRY", pHeadSelectedCity->maxHurryPopulation()));
+			}
+		}
+
+		iHurryAngerLength = pHeadSelectedCity->hurryAngerLength((HurryTypes)(widgetDataStruct.m_iData1));
+
+		if (iHurryAngerLength > 0)
+		{
+			szBuffer.append(NEWLINE);
+			szBuffer.append(gDLL->getText("TXT_KEY_MISC_ANGER_TURNS", GC.getDefineINT("HURRY_POP_ANGER"), (iHurryAngerLength + pHeadSelectedCity->getHurryAngerTimer())));
+		}
+
+		if (!(pHeadSelectedCity->isProductionUnit()) && !(pHeadSelectedCity->isProductionBuilding()))
+		{
+			szBuffer.append(NEWLINE);
+			szBuffer.append(gDLL->getText("TXT_KEY_MISC_UNIT_BUILDING_HURRY"));
+		}
+
+		if (!(GET_PLAYER(pHeadSelectedCity->getOwnerINLINE()).canHurry((HurryTypes)(widgetDataStruct.m_iData1))))
+		{
+			bFirst = true;
+
+			for (iI = 0; iI < GC.getNumCivicInfos(); iI++)
+			{
+				if (GC.getCivicInfo((CivicTypes)iI).isHurry(widgetDataStruct.m_iData1))
+				{
+					szTempBuffer = NEWLINE + gDLL->getText("TXT_KEY_REQUIRES");
+					setListHelp(szBuffer, szTempBuffer, GC.getCivicInfo((CivicTypes)iI).getDescription(), gDLL->getText("TXT_KEY_OR").c_str(), bFirst);
+					bFirst = false;
+				}
+			}		
+
+			if (!bFirst)
+			{
+				szBuffer.append(ENDCOLR);
+			}
+		}
+	}
+}
+
+
+void CvDLLWidgetData::parseConscriptHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	CvCity* pHeadSelectedCity;
+	CvWString szTempBuffer;
+	int iConscriptPopulation;
+	int iConscriptAngerLength;
+	int iMinCityPopulation;
+	int iMinCulturePercent;
+	int iI;
+	bool bFirst;
+
+	pHeadSelectedCity = gDLL->getInterfaceIFace()->getHeadSelectedCity();
+
+	if (pHeadSelectedCity != NULL)
+	{
+		if (pHeadSelectedCity->getConscriptUnit() != NO_UNIT)
+		{
+			CvWString szTemp;
+			szTemp.Format(SETCOLR L"%s" ENDCOLR, TEXT_COLOR("COLOR_UNIT_TEXT"), GC.getUnitInfo(pHeadSelectedCity->getConscriptUnit()).getDescription());
+			szBuffer.assign(szTemp);
+
+			iConscriptPopulation = pHeadSelectedCity->getConscriptPopulation();
+
+			if (iConscriptPopulation > 0)
+			{
+				szBuffer.append(NEWLINE);
+				szBuffer.append(gDLL->getText("TXT_KEY_MISC_HURRY_POP", iConscriptPopulation));
+			}
+
+			iConscriptAngerLength = pHeadSelectedCity->flatConscriptAngerLength();
+
+			if (iConscriptAngerLength > 0)
+			{
+				szBuffer.append(NEWLINE);
+				szBuffer.append(gDLL->getText("TXT_KEY_MISC_ANGER_TURNS", GC.getDefineINT("CONSCRIPT_POP_ANGER"), (iConscriptAngerLength + pHeadSelectedCity->getConscriptAngerTimer())));
+			}
+
+			iMinCityPopulation = pHeadSelectedCity->conscriptMinCityPopulation();
+
+			if (pHeadSelectedCity->getPopulation() < iMinCityPopulation)
+			{
+				szBuffer.append(NEWLINE);
+				szBuffer.append(gDLL->getText("TXT_KEY_MISC_MIN_CITY_POP", iMinCityPopulation));
+			}
+
+			iMinCulturePercent = GC.getDefineINT("CONSCRIPT_MIN_CULTURE_PERCENT");
+
+			if (pHeadSelectedCity->plot()->calculateTeamCulturePercent(pHeadSelectedCity->getTeam()) < iMinCulturePercent)
+			{
+				szBuffer.append(NEWLINE);
+				szBuffer.append(gDLL->getText("TXT_KEY_MISC_MIN_CULTURE_PERCENT", iMinCulturePercent));
+			}
+
+			if (GET_PLAYER(pHeadSelectedCity->getOwnerINLINE()).getMaxConscript() == 0)
+			{
+				bFirst = true;
+
+				for (iI = 0; iI < GC.getNumCivicInfos(); iI++)
+				{
+					if (getWorldSizeMaxConscript((CivicTypes)iI) > 0)
+					{
+						szTempBuffer = NEWLINE + gDLL->getText("TXT_KEY_REQUIRES");
+						setListHelp(szBuffer, szTempBuffer, GC.getCivicInfo((CivicTypes)iI).getDescription(), gDLL->getText("TXT_KEY_OR").c_str(), bFirst);
+						bFirst = false;
+					}
+				}		
+
+				if (!bFirst)
+				{
+					szBuffer.append(ENDCOLR);
+				}
+			}
+		}
+	}
+}
+
+
+void CvDLLWidgetData::parseActionHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	CLLNode<IDInfo>* pSelectedUnitNode;
+	CvCity* pMissionCity;
+	CvCity* pCity;
+	CvUnit* pHeadSelectedUnit;
+	CvUnit* pSelectedUnit;
+	CvPlot* pMissionPlot;
+	CvPlot* pLoopPlot;
+	CvWString szTempBuffer;
+	CvWString szFirstBuffer;
+	ImprovementTypes eImprovement;
+	ImprovementTypes eFinalImprovement;
+	ReligionTypes eReligion;
+	BuildingTypes eBuilding;
+	PlayerTypes eGiftPlayer;
+	BuildTypes eBuild;
+	RouteTypes eRoute;
+	BonusTypes eBonus;
+	TechTypes eTech;
+	bool bAlt;
+	bool bShift;
+	bool bValid;
+	int iYield;
+	int iUnitConsume;
+	int iUnitDiff;
+	int iProduction;
+	int iMovementCost;
+	int iFlatMovementCost;
+	int iMoves;
+	int iFlatMoves;
+	int iNowWorkRate;
+	int iThenWorkRate;
+	int iTurns;
+	int iPrice;
+	int iLow;
+	int iHigh;
+	int iLast;
+	int iRange;
+	int iDX, iDY;
+	int iI;
+
+	bAlt = gDLL->altKey();
+	bShift = gDLL->shiftKey();
+
+	CvWString szTemp;
+	szTemp.Format(SETCOLR L"%s" ENDCOLR , TEXT_COLOR("COLOR_HIGHLIGHT_TEXT"), GC.getActionInfo(widgetDataStruct.m_iData1).getHotKeyDescription().c_str());
+	szBuffer.assign(szTemp);
+
+	pHeadSelectedUnit = gDLL->getInterfaceIFace()->getHeadSelectedUnit();
+
+	if (pHeadSelectedUnit != NULL)
+	{
+		if (GC.getActionInfo(widgetDataStruct.m_iData1).getMissionType() != NO_MISSION)
+		{
+			if (bShift && gDLL->getInterfaceIFace()->mirrorsSelectionGroup())
+			{
+				pMissionPlot = pHeadSelectedUnit->getGroup()->lastMissionPlot();
+			}
+			else
+			{
+				pMissionPlot = pHeadSelectedUnit->plot();
+			}
+
+			pMissionCity = pMissionPlot->getPlotCity();
+
+			if (GC.getActionInfo(widgetDataStruct.m_iData1).getMissionType() == MISSION_HEAL)
+			{
+				iTurns = 0;
+
+				pSelectedUnitNode = gDLL->getInterfaceIFace()->headSelectionListNode();
+
+				while (pSelectedUnitNode != NULL)
+				{
+					pSelectedUnit = ::getUnit(pSelectedUnitNode->m_data);
+					iTurns = std::max(iTurns, pSelectedUnit->healTurns(pMissionPlot));
+
+					pSelectedUnitNode = gDLL->getInterfaceIFace()->nextSelectionListNode(pSelectedUnitNode);
+				}
+
+				szBuffer.append(NEWLINE);
+				szBuffer.append(gDLL->getText("TXT_KEY_MISC_TURN_OR_TURNS", iTurns));
+			}
+			else if (GC.getActionInfo(widgetDataStruct.m_iData1).getMissionType() == MISSION_PILLAGE)
+			{
+				if (pMissionPlot->getImprovementType() != NO_IMPROVEMENT)
+				{
+					szBuffer.append(NEWLINE);
+					szBuffer.append(gDLL->getText("TXT_KEY_ACTION_DESTROY_IMP", GC.getImprovementInfo(pMissionPlot->getImprovementType()).getTextKeyWide()));
+				}
+				else if (pMissionPlot->getRouteType() != NO_ROUTE)
+				{
+					szBuffer.append(NEWLINE);
+					szBuffer.append(gDLL->getText("TXT_KEY_ACTION_DESTROY_IMP", GC.getRouteInfo(pMissionPlot->getRouteType()).getTextKeyWide()));
+				}
+			}
+			else if (GC.getActionInfo(widgetDataStruct.m_iData1).getMissionType() == MISSION_PLUNDER)
+			{
+				pMissionPlot = pHeadSelectedUnit->plot();
+
+				if (pMissionPlot->getTeam() == pHeadSelectedUnit->getTeam())
+				{
+					szBuffer.append(NEWLINE);
+					szBuffer.append(gDLL->getText("TXT_KEY_ACTION_PLUNDER_IN_BORDERS"));
+				}
+			}
+			else if (GC.getActionInfo(widgetDataStruct.m_iData1).getMissionType() == MISSION_SABOTAGE)
+			{
+				pSelectedUnitNode = gDLL->getInterfaceIFace()->headSelectionListNode();
+
+				while (pSelectedUnitNode != NULL)
+				{
+					pSelectedUnit = ::getUnit(pSelectedUnitNode->m_data);
+
+					if (pSelectedUnit->canSabotage(pMissionPlot, true)) // XXX if queuing up this action, use the current plot along the goto...
+					{
+						iPrice = pSelectedUnit->sabotageCost(pMissionPlot);
+						if (iPrice > 0)
+						{
+							szTempBuffer.Format(L"%d %c", iPrice, GC.getCommerceInfo(COMMERCE_GOLD).getChar());
+							szBuffer.append(NEWLINE);
+							szBuffer.append(szTempBuffer);
+						}
+
+						iLow = pSelectedUnit->sabotageProb(pMissionPlot, PROBABILITY_LOW);
+						iHigh = pSelectedUnit->sabotageProb(pMissionPlot, PROBABILITY_HIGH);
+
+						if (iLow == iHigh)
+						{
+							szBuffer.append(NEWLINE);
+							szBuffer.append(gDLL->getText("TXT_KEY_ACTION_PROBABILITY", iHigh));
+						}
+						else
+						{
+							szBuffer.append(NEWLINE);
+							szBuffer.append(gDLL->getText("TXT_KEY_ACTION_PROBABILITY_RANGE", iLow, iHigh));
+						}
+						break;
+					}
+
+					pSelectedUnitNode = gDLL->getInterfaceIFace()->nextSelectionListNode(pSelectedUnitNode);
+				}
+			}
+			else if (GC.getActionInfo(widgetDataStruct.m_iData1).getMissionType() == MISSION_DESTROY)
+			{
+				pSelectedUnitNode = gDLL->getInterfaceIFace()->headSelectionListNode();
+
+				while (pSelectedUnitNode != NULL)
+				{
+					pSelectedUnit = ::getUnit(pSelectedUnitNode->m_data);
+
+					if (pSelectedUnit->canDestroy(pMissionPlot, true)) // XXX if queuing up this action, use the current plot along the goto...
+					{
+						iPrice = pSelectedUnit->destroyCost(pMissionPlot);
+						if (iPrice > 0)
+						{
+							szTempBuffer.Format(L"%d %c", iPrice, GC.getCommerceInfo(COMMERCE_GOLD).getChar());
+							szBuffer.append(NEWLINE);
+							szBuffer.append(szTempBuffer);
+						}
+
+						iLow = pSelectedUnit->destroyProb(pMissionPlot, PROBABILITY_LOW);
+						iHigh = pSelectedUnit->destroyProb(pMissionPlot, PROBABILITY_HIGH);
+
+						if (iLow == iHigh)
+						{
+							szBuffer.append(NEWLINE);
+							szBuffer.append(gDLL->getText("TXT_KEY_ACTION_PROBABILITY", iHigh));
+						}
+						else
+						{
+							szBuffer.append(NEWLINE);
+							szBuffer.append(gDLL->getText("TXT_KEY_ACTION_PROBABILITY_RANGE", iLow, iHigh));
+						}
+						break;
+					}
+
+					pSelectedUnitNode = gDLL->getInterfaceIFace()->nextSelectionListNode(pSelectedUnitNode);
+				}
+			}
+			else if (GC.getActionInfo(widgetDataStruct.m_iData1).getMissionType() == MISSION_STEAL_PLANS)
+			{
+				pSelectedUnitNode = gDLL->getInterfaceIFace()->headSelectionListNode();
+
+				while (pSelectedUnitNode != NULL)
+				{
+					pSelectedUnit = ::getUnit(pSelectedUnitNode->m_data);
+
+					if (pSelectedUnit->canStealPlans(pMissionPlot, true)) // XXX if queuing up this action, use the current plot along the goto...
+					{
+						iPrice = pSelectedUnit->stealPlansCost(pMissionPlot);
+						if (iPrice > 0)
+						{
+							szTempBuffer.Format(L"%d %c", iPrice, GC.getCommerceInfo(COMMERCE_GOLD).getChar());
+							szBuffer.append(NEWLINE);
+							szBuffer.append(szTempBuffer);
+						}
+
+						iLow = pSelectedUnit->stealPlansProb(pMissionPlot, PROBABILITY_LOW);
+						iHigh = pSelectedUnit->stealPlansProb(pMissionPlot, PROBABILITY_HIGH);
+
+						if (iLow == iHigh)
+						{
+							szBuffer.append(NEWLINE);
+							szBuffer.append(gDLL->getText("TXT_KEY_ACTION_PROBABILITY", iHigh));
+						}
+						else
+						{
+							szBuffer.append(NEWLINE);
+							szBuffer.append(gDLL->getText("TXT_KEY_ACTION_PROBABILITY_RANGE", iLow, iHigh));
+						}
+						break;
+					}
+
+					pSelectedUnitNode = gDLL->getInterfaceIFace()->nextSelectionListNode(pSelectedUnitNode);
+				}
+			}
+			else if (GC.getActionInfo(widgetDataStruct.m_iData1).getMissionType() == MISSION_FOUND)
+			{
+				if (!(GET_PLAYER(pHeadSelectedUnit->getOwnerINLINE()).canFound(pMissionPlot->getX_INLINE(), pMissionPlot->getY_INLINE())))
+				{
+					bValid = true;
+
+					iRange = GC.getMIN_CITY_RANGE();
+
+					for (iDX = -(iRange); iDX <= iRange; iDX++)
+					{
+						for (iDY = -(iRange); iDY <= iRange; iDY++)
+						{
+							pLoopPlot	= plotXY(pMissionPlot->getX_INLINE(), pMissionPlot->getY_INLINE(), iDX, iDY);
+
+							if (pLoopPlot != NULL)
+							{
+								if (pLoopPlot->isCity())
+								{
+									bValid = false;
+								}
+							}
+						}
+					}
+
+					if (!bValid)
+					{
+						szBuffer.append(NEWLINE);
+						szBuffer.append(gDLL->getText("TXT_KEY_ACTION_CANNOT_FOUND", GC.getMIN_CITY_RANGE()));
+					}
+				}
+			}
+			else if (GC.getActionInfo(widgetDataStruct.m_iData1).getMissionType() == MISSION_SPREAD)
+			{
+				eReligion = ((ReligionTypes)(GC.getActionInfo(widgetDataStruct.m_iData1).getMissionData()));
+
+				if (pMissionCity != NULL)
+				{
+					if (pMissionCity->getTeam() != pHeadSelectedUnit->getTeam()) // XXX still true???
+					{
+						if (GET_PLAYER(pMissionCity->getOwnerINLINE()).isNoNonStateReligionSpread())
+						{
+							if (eReligion != GET_PLAYER(pMissionCity->getOwnerINLINE()).getStateReligion())
+							{
+								szBuffer.append(NEWLINE);
+								szBuffer.append(gDLL->getText("TXT_KEY_ACTION_CANNOT_SPREAD_NON_STATE_RELIGION"));
+							}
+						}
+					}
+
+					szBuffer.append(NEWLINE);
+					GAMETEXT.setReligionHelpCity(szBuffer, eReligion, pMissionCity, false, true);
+				}
+			}
+			else if (GC.getActionInfo(widgetDataStruct.m_iData1).getMissionType() == MISSION_SPREAD_CORPORATION)
+			{
+				CorporationTypes eCorporation = ((CorporationTypes)(GC.getActionInfo(widgetDataStruct.m_iData1).getMissionData()));
+
+				if (pMissionCity != NULL)
+				{
+					szBuffer.append(NEWLINE);
+					GAMETEXT.setCorporationHelpCity(szBuffer, eCorporation, pMissionCity, false, true);
+
+					for (int iCorp = 0; iCorp < GC.getNumCorporationInfos(); ++iCorp)
+					{
+						if (eCorporation != iCorp)
+						{
+							if (pMissionCity->isHasCorporation((CorporationTypes)iCorp))
+							{
+								if (GC.getGameINLINE().isCompetingCorporation(eCorporation, (CorporationTypes)iCorp))
+								{
+									szBuffer.append(NEWLINE);
+									szBuffer.append(gDLL->getText("TXT_KEY_ACTION_WILL_ELIMINATE_CORPORATION", GC.getCorporationInfo((CorporationTypes)iCorp).getTextKeyWide()));
+								}
+							}
+						}
+					}
+
+					szTempBuffer.Format(L"%s%d %c", NEWLINE, pHeadSelectedUnit->spreadCorporationCost(eCorporation, pMissionCity), GC.getCommerceInfo(COMMERCE_GOLD).getChar());
+					szBuffer.append(szTempBuffer);
+
+					if (!pHeadSelectedUnit->canSpreadCorporation(pMissionPlot, eCorporation))
+					{
+						if (!GET_PLAYER(pMissionCity->getOwnerINLINE()).isActiveCorporation(eCorporation))
+						{
+							szBuffer.append(NEWLINE);
+							szBuffer.append(gDLL->getText("TXT_KEY_ACTION_CORPORATION_NOT_ACTIVE", GC.getCorporationInfo(eCorporation).getTextKeyWide(), GET_PLAYER(pMissionCity->getOwnerINLINE()).getCivilizationAdjective()));
+						}
+
+						CorporationTypes eCompetition = NO_CORPORATION;
+						for (int iCorporation = 0; iCorporation < GC.getNumCorporationInfos(); ++iCorporation)
+						{
+							if (pMissionCity->isHeadquarters((CorporationTypes)iCorporation))
+							{
+								if (GC.getGameINLINE().isCompetingCorporation((CorporationTypes)iCorporation, eCorporation))
+								{
+									eCompetition = (CorporationTypes)iCorporation;
+									break;
+								}
+							}
+						}
+
+						if (NO_CORPORATION != eCompetition)
+						{
+							szBuffer.append(NEWLINE);
+							szBuffer.append(gDLL->getText("TXT_KEY_ACTION_CORPORATION_COMPETING_HEADQUARTERS", GC.getCorporationInfo(eCorporation).getTextKeyWide(), GC.getCorporationInfo(eCompetition).getTextKeyWide()));
+						}
+
+						CvWStringBuffer szBonusList;
+						bool bValid = false;
+						bool bFirst = true;
+						for (int i = 0; i < GC.getNUM_CORPORATION_PREREQ_BONUSES(); ++i)
+						{
+							BonusTypes eBonus = (BonusTypes)GC.getCorporationInfo(eCorporation).getPrereqBonus(i);
+							if (NO_BONUS != eBonus)
+							{
+								if (!bFirst)
+								{
+									szBonusList.append(L", ");
+								}
+								else
+								{
+									bFirst = false;
+								}
+								szBonusList.append(GC.getBonusInfo(eBonus).getDescription());
+
+								if (pMissionCity->hasBonus(eBonus))
+								{
+									bValid = true;
+									break;
+								}
+							}
+						}
+
+						if (!bValid)
+						{
+							szBuffer.append(NEWLINE);
+							szBuffer.append(gDLL->getText("TXT_KEY_ACTION_CORPORATION_NO_RESOURCES", pMissionCity->getNameKey(), szBonusList.getCString()));
+						}
+					}
+				}
+			}
+			else if (GC.getActionInfo(widgetDataStruct.m_iData1).getMissionType() == MISSION_JOIN)
+			{
+				GAMETEXT.parseSpecialistHelp(szBuffer, ((SpecialistTypes)(GC.getActionInfo(widgetDataStruct.m_iData1).getMissionData())), pMissionCity, true);
+			}
+			else if (GC.getActionInfo(widgetDataStruct.m_iData1).getMissionType() == MISSION_CONSTRUCT)
+			{
+				eBuilding = ((BuildingTypes)(GC.getActionInfo(widgetDataStruct.m_iData1).getMissionData()));
+
+				if (pMissionCity != NULL)
+				{
+					if (!pHeadSelectedUnit->getUnitInfo().getForceBuildings(eBuilding)  && !pMissionCity->canConstruct(eBuilding, false, false, true))
+					{
+						if (!(GC.getGameINLINE().isBuildingClassMaxedOut((BuildingClassTypes)(GC.getBuildingInfo(eBuilding).getBuildingClassType()))))
+						{
+							GAMETEXT.buildBuildingRequiresString(szBuffer, ((BuildingTypes)(GC.getActionInfo(widgetDataStruct.m_iData1).getMissionData())), false, false, pMissionCity);
+						}
+					}
+					else
+					{
+						szBuffer.append(NEWLINE);
+						GAMETEXT.setBuildingHelp(szBuffer, ((BuildingTypes)(GC.getActionInfo(widgetDataStruct.m_iData1).getMissionData())), false, false, false, pMissionCity);
+					}
+				}
+			}
+			else if (GC.getActionInfo(widgetDataStruct.m_iData1).getMissionType() == MISSION_DISCOVER)
+			{
+				pSelectedUnitNode = gDLL->getInterfaceIFace()->headSelectionListNode();
+
+				while (pSelectedUnitNode != NULL)
+				{
+					pSelectedUnit = ::getUnit(pSelectedUnitNode->m_data);
+
+					if (pSelectedUnit->canDiscover(pMissionPlot))
+					{
+						eTech = pSelectedUnit->getDiscoveryTech();
+	
+						if (pSelectedUnit->getDiscoverResearch(eTech) >= GET_TEAM(pSelectedUnit->getTeam()).getResearchLeft(eTech))
+						{
+							szTempBuffer.Format(SETCOLR L"%s" ENDCOLR, TEXT_COLOR("COLOR_TECH_TEXT"), GC.getTechInfo(eTech).getDescription());
+							szBuffer.append(NEWLINE);
+							szBuffer.append(szTempBuffer);
+						}
+						else
+						{
+							szBuffer.append(NEWLINE);
+							szBuffer.append(gDLL->getText("TXT_KEY_ACTION_EXTRA_RESEARCH", pSelectedUnit->getDiscoverResearch(eTech), GC.getTechInfo(eTech).getTextKeyWide()));
+						}
+						break;
+					}
+
+					pSelectedUnitNode = gDLL->getInterfaceIFace()->nextSelectionListNode(pSelectedUnitNode);
+				}
+			}
+			else if (GC.getActionInfo(widgetDataStruct.m_iData1).getMissionType() == MISSION_HURRY)
+			{
+				if (pMissionCity != NULL)
+				{
+					if (!(pMissionCity->isProductionBuilding()))
+					{
+						szBuffer.append(NEWLINE);
+						szBuffer.append(gDLL->getText("TXT_KEY_ACTION_BUILDING_HURRY"));
+					}
+					else
+					{
+						pSelectedUnitNode = gDLL->getInterfaceIFace()->headSelectionListNode();
+
+						while (pSelectedUnitNode != NULL)
+						{
+							pSelectedUnit = ::getUnit(pSelectedUnitNode->m_data);
+
+							if (pSelectedUnit->canHurry(pMissionPlot, true))
+							{
+								const wchar* pcKey = NULL;
+								if (NO_PROJECT != pMissionCity->getProductionProject())
+								{
+									pcKey = GC.getProjectInfo(pMissionCity->getProductionProject()).getTextKeyWide();
+								}
+								else if (NO_BUILDING != pMissionCity->getProductionBuilding())
+								{
+									pcKey = GC.getBuildingInfo(pMissionCity->getProductionBuilding()).getTextKeyWide();
+								}
+								else if (NO_UNIT != pMissionCity->getProductionUnit())
+								{
+									pcKey = GC.getUnitInfo(pMissionCity->getProductionUnit()).getTextKeyWide();
+								}
+								if (NULL != pcKey && pSelectedUnit->getHurryProduction(pMissionPlot) >= pMissionCity->productionLeft())
+								{
+									szBuffer.append(NEWLINE);
+									szBuffer.append(gDLL->getText("TXT_KEY_ACTION_FINISH_CONSTRUCTION", pcKey));
+								}
+								else
+								{
+									szBuffer.append(NEWLINE);
+									szBuffer.append(gDLL->getText("TXT_KEY_ACTION_EXTRA_CONSTRUCTION", pSelectedUnit->getHurryProduction(pMissionPlot), pcKey));
+								}
+								break;
+							}
+
+							pSelectedUnitNode = gDLL->getInterfaceIFace()->nextSelectionListNode(pSelectedUnitNode);
+						}
+					}
+				}
+			}
+			else if (GC.getActionInfo(widgetDataStruct.m_iData1).getMissionType() == MISSION_TRADE)
+			{
+				if (pMissionCity != NULL)
+				{
+					if (pMissionCity->getOwnerINLINE() == pHeadSelectedUnit->getOwnerINLINE())
+					{
+						szBuffer.append(NEWLINE);
+						szBuffer.append(gDLL->getText("TXT_KEY_ACTION_TRADE_MISSION_FOREIGN"));
+					}
+					else
+					{
+						pSelectedUnitNode = gDLL->getInterfaceIFace()->headSelectionListNode();
+
+						while (pSelectedUnitNode != NULL)
+						{
+							pSelectedUnit = ::getUnit(pSelectedUnitNode->m_data);
+
+							if (pSelectedUnit->canTrade(pMissionPlot, true))
+							{
+								szTempBuffer.Format(L"%s+%d%c", NEWLINE, pSelectedUnit->getTradeGold(pMissionPlot), GC.getCommerceInfo(COMMERCE_GOLD).getChar());
+								szBuffer.append(szTempBuffer);
+								break;
+							}
+
+							pSelectedUnitNode = gDLL->getInterfaceIFace()->nextSelectionListNode(pSelectedUnitNode);
+						}
+					}
+				}
+			}
+			else if (GC.getActionInfo(widgetDataStruct.m_iData1).getMissionType() == MISSION_GREAT_WORK)
+			{
+				pSelectedUnitNode = gDLL->getInterfaceIFace()->headSelectionListNode();
+
+				while (pSelectedUnitNode != NULL)
+				{
+					pSelectedUnit = ::getUnit(pSelectedUnitNode->m_data);
+
+					if (pSelectedUnit->canGreatWork(pMissionPlot))
+					{
+						szTempBuffer.Format(L"%s+%d%c", NEWLINE, pSelectedUnit->getGreatWorkCulture(pMissionPlot), GC.getCommerceInfo(COMMERCE_CULTURE).getChar());
+						szBuffer.append(szTempBuffer);
+						break;
+					}
+
+					pSelectedUnitNode = gDLL->getInterfaceIFace()->nextSelectionListNode(pSelectedUnitNode);
+				}
+			}
+			else if (GC.getActionInfo(widgetDataStruct.m_iData1).getMissionType() == MISSION_INFILTRATE)
+			{
+				if (pMissionCity != NULL)
+				{
+					if (pMissionCity->getOwnerINLINE() == pHeadSelectedUnit->getOwnerINLINE())
+					{
+						szBuffer.append(NEWLINE);
+						szBuffer.append(gDLL->getText("TXT_KEY_ACTION_INFILTRATE_MISSION_FOREIGN"));
+					}
+					else
+					{
+						pSelectedUnitNode = gDLL->getInterfaceIFace()->headSelectionListNode();
+
+						while (pSelectedUnitNode != NULL)
+						{
+							pSelectedUnit = ::getUnit(pSelectedUnitNode->m_data);
+
+							if (pSelectedUnit->canEspionage(pMissionPlot))
+							{
+								szTempBuffer.Format(L"%s+%d%c", NEWLINE, pSelectedUnit->getEspionagePoints(pMissionPlot), GC.getCommerceInfo(COMMERCE_ESPIONAGE).getChar());
+								szBuffer.append(szTempBuffer);
+								break;
+							}
+
+							pSelectedUnitNode = gDLL->getInterfaceIFace()->nextSelectionListNode(pSelectedUnitNode);
+						}
+					}
+				}
+			}
+			else if (GC.getActionInfo(widgetDataStruct.m_iData1).getMissionType() == MISSION_GOLDEN_AGE)
+			{
+				iUnitConsume = GET_PLAYER(pHeadSelectedUnit->getOwnerINLINE()).unitsRequiredForGoldenAge();
+				iUnitDiff = (iUnitConsume - GET_PLAYER(pHeadSelectedUnit->getOwnerINLINE()).unitsGoldenAgeReady());
+
+				if (iUnitDiff > 0)
+				{
+					szBuffer.append(NEWLINE);
+					szBuffer.append(gDLL->getText("TXT_KEY_ACTION_MORE_GREAT_PEOPLE", iUnitDiff));
+				}
+
+				if (iUnitConsume > 1)
+				{
+					szBuffer.append(NEWLINE);
+					szBuffer.append(gDLL->getText("TXT_KEY_ACTION_CONSUME_GREAT_PEOPLE", iUnitConsume));
+				}
+			}
+			else if (GC.getActionInfo(widgetDataStruct.m_iData1).getMissionType() == MISSION_LEAD)
+			{
+				if (pHeadSelectedUnit->getUnitInfo().getLeaderExperience() > 0)
+				{
+					int iNumUnits = pHeadSelectedUnit->canGiveExperience(pHeadSelectedUnit->plot());
+					if (iNumUnits > 0)
+					{
+						szBuffer.append(NEWLINE);
+						szBuffer.append(gDLL->getText("TXT_KEY_ACTION_LEAD_TROOPS", pHeadSelectedUnit->getStackExperienceToGive(iNumUnits)));
+					}
+				}
+				if (pHeadSelectedUnit->getUnitInfo().getLeaderPromotion() != NO_PROMOTION)
+				{
+					szBuffer.append(NEWLINE);
+					szBuffer.append(gDLL->getText("TXT_KEY_PROMOTION_WHEN_LEADING"));
+					GAMETEXT.parsePromotionHelp(szBuffer, (PromotionTypes)pHeadSelectedUnit->getUnitInfo().getLeaderPromotion(), L"\n   ");
+				}
+			}
+			else if (GC.getActionInfo(widgetDataStruct.m_iData1).getMissionType() == MISSION_ESPIONAGE)
+			{
+				szBuffer.append(NEWLINE);
+				szBuffer.append(gDLL->getText("TXT_KEY_ACTION_ESPIONAGE_MISSION"));
+
+				GAMETEXT.setEspionageMissionHelp(szBuffer, pHeadSelectedUnit);
+			}
+			else if (GC.getActionInfo(widgetDataStruct.m_iData1).getMissionType() == MISSION_BUILD)
+			{
+				eBuild = ((BuildTypes)(GC.getActionInfo(widgetDataStruct.m_iData1).getMissionData()));
+				FAssert(eBuild != NO_BUILD);
+				eImprovement = ((ImprovementTypes)(GC.getBuildInfo(eBuild).getImprovement()));
+				eRoute = ((RouteTypes)(GC.getBuildInfo(eBuild).getRoute()));
+				eBonus = pMissionPlot->getBonusType(pHeadSelectedUnit->getTeam());
+
+				for (iI = 0; iI < NUM_YIELD_TYPES; iI++)
+				{
+					iYield = 0;
+
+					if (eImprovement != NO_IMPROVEMENT)
+					{
+						iYield += pMissionPlot->calculateImprovementYieldChange(eImprovement, ((YieldTypes)iI), pHeadSelectedUnit->getOwnerINLINE());
+						if (pMissionPlot->getImprovementType() != NO_IMPROVEMENT)
+						{
+							iYield -= pMissionPlot->calculateImprovementYieldChange(pMissionPlot->getImprovementType(), ((YieldTypes)iI), pHeadSelectedUnit->getOwnerINLINE());
+						}
+					}
+
+					if (NO_FEATURE != pMissionPlot->getFeatureType())
+					{
+						if (GC.getBuildInfo(eBuild).isFeatureRemove(pMissionPlot->getFeatureType()))
+						{
+							iYield -= GC.getFeatureInfo(pMissionPlot->getFeatureType()).getYieldChange(iI);
+						}
+					}
+
+					if (iYield != 0)
+					{
+						szTempBuffer.Format(L", %s%d%c", ((iYield > 0) ? "+" : ""), iYield, GC.getYieldInfo((YieldTypes) iI).getChar());
+						szBuffer.append(szTempBuffer);
+					}
+				}
+
+				if (NO_IMPROVEMENT != eImprovement)
+				{
+					int iHappy = GC.getImprovementInfo(eImprovement).getHappiness();
+
+					if (iHappy != 0)
+					{
+						szTempBuffer.Format(L", +%d%c", abs(iHappy), (iHappy > 0 ? gDLL->getSymbolID(HAPPY_CHAR) : gDLL->getSymbolID(UNHAPPY_CHAR)));
+						szBuffer.append(szTempBuffer);
+					}
+				}
+
+				bValid = false;
+
+				pSelectedUnitNode = gDLL->getInterfaceIFace()->headSelectionListNode();
+
+				while (pSelectedUnitNode != NULL)
+				{
+					pSelectedUnit = ::getUnit(pSelectedUnitNode->m_data);
+
+					if (pSelectedUnit->canBuild(pMissionPlot, eBuild))
+					{
+						bValid = true;
+						break;
+					}
+
+					pSelectedUnitNode = gDLL->getInterfaceIFace()->nextSelectionListNode(pSelectedUnitNode);
+				}
+
+				if (!bValid)
+				{
+					if (eImprovement != NO_IMPROVEMENT)
+					{
+						if (pMissionPlot->getTeam() != pHeadSelectedUnit->getTeam())
+						{
+							if (GC.getImprovementInfo(eImprovement).isOutsideBorders())
+							{
+								if (pMissionPlot->getTeam() != NO_TEAM)
+								{
+									szBuffer.append(NEWLINE);
+									szBuffer.append(gDLL->getText("TXT_KEY_ACTION_NEEDS_OUT_RIVAL_CULTURE_BORDER"));
+								}
+							}
+							else
+							{
+								szBuffer.append(NEWLINE);
+								szBuffer.append(gDLL->getText("TXT_KEY_ACTION_NEEDS_CULTURE_BORDER"));
+							}
+						}
+
+						if ((eBonus == NO_BONUS) || !(GC.getImprovementInfo(eImprovement).isImprovementBonusTrade(eBonus)))
+						{
+							if (!(GET_TEAM(pHeadSelectedUnit->getTeam()).isIrrigation()) && !(GET_TEAM(pHeadSelectedUnit->getTeam()).isIgnoreIrrigation()))
+							{
+								if (GC.getImprovementInfo(eImprovement).isRequiresIrrigation() && !(pMissionPlot->isIrrigationAvailable()))
+								{
+									for (iI = 0; iI < GC.getNumTechInfos(); iI++)
+									{
+										if (GC.getTechInfo((TechTypes)iI).isIrrigation())
+										{
+											szBuffer.append(NEWLINE);
+											szBuffer.append(gDLL->getText("TXT_KEY_BUILDING_REQUIRES_STRING", GC.getTechInfo((TechTypes)iI).getTextKeyWide()));
+											break;
+										}
+									}
+								}
+							}
+						}
+					}
+
+					if (!(GET_TEAM(pHeadSelectedUnit->getTeam()).isHasTech((TechTypes)GC.getBuildInfo(eBuild).getTechPrereq())))
+					{
+						szBuffer.append(NEWLINE);
+						szBuffer.append(gDLL->getText("TXT_KEY_BUILDING_REQUIRES_STRING", GC.getTechInfo((TechTypes) GC.getBuildInfo(eBuild).getTechPrereq()).getTextKeyWide()));
+					}
+
+					if (eRoute != NO_ROUTE)
+					{
+						if (GC.getRouteInfo(eRoute).getPrereqBonus() != NO_BONUS)
+						{
+							if (!(pMissionPlot->isAdjacentPlotGroupConnectedBonus(pHeadSelectedUnit->getOwnerINLINE(), ((BonusTypes)(GC.getRouteInfo(eRoute).getPrereqBonus())))))
+							{
+								szBuffer.append(NEWLINE);
+								szBuffer.append(gDLL->getText("TXT_KEY_BUILDING_REQUIRES_STRING", GC.getBonusInfo((BonusTypes) GC.getRouteInfo(eRoute).getPrereqBonus()).getTextKeyWide()));
+							}
+						}
+
+						bool bFoundValid = true;
+						std::vector<BonusTypes> aeOrBonuses;
+						for (int i = 0; i < GC.getNUM_ROUTE_PREREQ_OR_BONUSES(); ++i)
+						{
+							if (NO_BONUS != GC.getRouteInfo(eRoute).getPrereqOrBonus(i))
+							{
+								aeOrBonuses.push_back((BonusTypes)GC.getRouteInfo(eRoute).getPrereqOrBonus(i));
+								bFoundValid = false;
+
+								if (pMissionPlot->isAdjacentPlotGroupConnectedBonus(pHeadSelectedUnit->getOwnerINLINE(), ((BonusTypes)(GC.getRouteInfo(eRoute).getPrereqOrBonus(i)))))
+								{
+									bFoundValid = true;
+									break;
+								}
+							}
+						}
+
+						if (!bFoundValid)
+						{
+							bool bFirst = true;
+							for (std::vector<BonusTypes>::iterator it = aeOrBonuses.begin(); it != aeOrBonuses.end(); ++it)
+							{
+								szFirstBuffer = NEWLINE + gDLL->getText("TXT_KEY_BUILDING_REQUIRES_LIST");
+								szTempBuffer.Format( SETCOLR L"<link=literal>%s</link>" ENDCOLR , TEXT_COLOR("COLOR_HIGHLIGHT_TEXT"), GC.getBonusInfo(*it).getDescription());
+								setListHelp(szBuffer, szFirstBuffer.GetCString(), szTempBuffer, gDLL->getText("TXT_KEY_OR").c_str(), bFirst);
+								bFirst = false;
+							}
+						}
+					}
+
+					if (pMissionPlot->getFeatureType() != NO_FEATURE)
+					{
+						if (!(GET_TEAM(pHeadSelectedUnit->getTeam()).isHasTech((TechTypes)GC.getBuildInfo(eBuild).getFeatureTech(pMissionPlot->getFeatureType()))))
+						{
+							szBuffer.append(NEWLINE);
+							szBuffer.append(gDLL->getText("TXT_KEY_BUILDING_REQUIRES_STRING", GC.getTechInfo((TechTypes) GC.getBuildInfo(eBuild).getFeatureTech(pMissionPlot->getFeatureType())).getTextKeyWide()));
+						}
+					}
+				}
+
+				if (eImprovement != NO_IMPROVEMENT)
+				{
+					if (pMissionPlot->getImprovementType() != NO_IMPROVEMENT)
+					{
+						szBuffer.append(NEWLINE);
+						szBuffer.append(gDLL->getText("TXT_KEY_ACTION_WILL_DESTROY_IMP", GC.getImprovementInfo(pMissionPlot->getImprovementType()).getTextKeyWide()));
+					}
+				}
+
+				if (GC.getBuildInfo(eBuild).isKill())
+				{
+					szBuffer.append(NEWLINE);
+					szBuffer.append(gDLL->getText("TXT_KEY_ACTION_CONSUME_UNIT"));
+				}
+
+				if (pMissionPlot->getFeatureType() != NO_FEATURE)
+				{
+					if (GC.getBuildInfo(eBuild).isFeatureRemove(pMissionPlot->getFeatureType()))
+					{
+						iProduction = pMissionPlot->getFeatureProduction(eBuild, pHeadSelectedUnit->getTeam(), &pCity);
+
+						if (iProduction > 0)
+						{
+							szBuffer.append(NEWLINE);
+							szBuffer.append(gDLL->getText("TXT_KEY_ACTION_CHANGE_PRODUCTION", iProduction, pCity->getNameKey()));
+						}
+
+						szBuffer.append(NEWLINE);
+						szBuffer.append(gDLL->getText("TXT_KEY_ACTION_REMOVE_FEATURE", GC.getFeatureInfo(pMissionPlot->getFeatureType()).getTextKeyWide()));
+					}
+
+				}
+
+				if (eImprovement != NO_IMPROVEMENT)
+				{
+					if (eBonus != NO_BONUS)
+					{
+						if (!GET_TEAM(pHeadSelectedUnit->getTeam()).isBonusObsolete(eBonus))
+						{
+							if (GC.getImprovementInfo(eImprovement).isImprovementBonusTrade(eBonus))
+							{
+								szBuffer.append(NEWLINE);
+								szBuffer.append(gDLL->getText("TXT_KEY_ACTION_PROVIDES_BONUS", GC.getBonusInfo(eBonus).getTextKeyWide()));
+
+								if (GC.getBonusInfo(eBonus).getHealth() != 0)
+								{
+									szTempBuffer.Format(L" (+%d%c)", abs(GC.getBonusInfo(eBonus).getHealth()), ((GC.getBonusInfo(eBonus).getHealth() > 0) ? gDLL->getSymbolID(HEALTHY_CHAR) : gDLL->getSymbolID(UNHEALTHY_CHAR)));
+									szBuffer.append(szTempBuffer);
+								}
+
+								if (GC.getBonusInfo(eBonus).getHappiness() != 0)
+								{
+									szTempBuffer.Format(L" (+%d%c)", abs(GC.getBonusInfo(eBonus).getHappiness()), ((GC.getBonusInfo(eBonus).getHappiness() > 0) ? gDLL->getSymbolID(HAPPY_CHAR) : gDLL->getSymbolID(UNHAPPY_CHAR)));
+									szBuffer.append(szTempBuffer);
+								}
+							}
+						}
+					}
+					else
+					{
+						iLast = 0;
+
+						FAssert((0 < GC.getNumBonusInfos()) && "GC.getNumBonusInfos() is not greater than zero but an array is being allocated in CvDLLWidgetData::parseActionHelp");
+						for (iI = 0; iI < GC.getNumBonusInfos(); iI++)
+						{
+							if (GET_TEAM(pHeadSelectedUnit->getTeam()).isHasTech((TechTypes)(GC.getBonusInfo((BonusTypes) iI).getTechReveal())))
+							{
+								if (GC.getImprovementInfo(eImprovement).getImprovementBonusDiscoverRand(iI) > 0)
+								{
+									szFirstBuffer.Format(L"%s%s", NEWLINE, gDLL->getText("TXT_KEY_ACTION_CHANCE_DISCOVER").c_str());
+									szTempBuffer.Format(L"%c", GC.getBonusInfo((BonusTypes) iI).getChar());
+									setListHelp(szBuffer, szFirstBuffer, szTempBuffer, L", ", (GC.getImprovementInfo(eImprovement).getImprovementBonusDiscoverRand(iI) != iLast));
+									iLast = GC.getImprovementInfo(eImprovement).getImprovementBonusDiscoverRand(iI);
+								}
+							}
+						}
+					}
+
+					if (!(pMissionPlot->isIrrigationAvailable()))
+					{
+						GAMETEXT.setYieldChangeHelp(szBuffer, gDLL->getText("TXT_KEY_ACTION_IRRIGATED").c_str(), L": ", L"", GC.getImprovementInfo(eImprovement).getIrrigatedYieldChangeArray());
+					}
+
+					if (eRoute == NO_ROUTE)
+					{
+						for (iI = 0; iI < GC.getNumRouteInfos(); iI++)
+						{
+							if (pMissionPlot->getRouteType() != ((RouteTypes)iI))
+							{
+								GAMETEXT.setYieldChangeHelp(szBuffer, GC.getRouteInfo((RouteTypes)iI).getDescription(), L": ", L"", GC.getImprovementInfo(eImprovement).getRouteYieldChangesArray((RouteTypes)iI));
+							}
+						}
+					}
+
+					if (GC.getImprovementInfo(eImprovement).getDefenseModifier() != 0)
+					{
+						szBuffer.append(NEWLINE);
+						szBuffer.append(gDLL->getText("TXT_KEY_ACTION_DEFENSE_MODIFIER", GC.getImprovementInfo(eImprovement).getDefenseModifier()));
+					}
+
+					if (GC.getImprovementInfo(eImprovement).getImprovementUpgrade() != NO_IMPROVEMENT)
+					{
+						iTurns = pMissionPlot->getUpgradeTimeLeft(eImprovement, pHeadSelectedUnit->getOwnerINLINE());
+
+						szBuffer.append(NEWLINE);
+						szBuffer.append(gDLL->getText("TXT_KEY_ACTION_BECOMES_IMP", GC.getImprovementInfo((ImprovementTypes) GC.getImprovementInfo(eImprovement).getImprovementUpgrade()).getTextKeyWide(), iTurns));
+					}
+				}
+
+				if (eRoute != NO_ROUTE)
+				{
+					eFinalImprovement = eImprovement;
+
+					if (eFinalImprovement == NO_IMPROVEMENT)
+					{
+						eFinalImprovement = pMissionPlot->getImprovementType();
+					}
+
+					if (eFinalImprovement != NO_IMPROVEMENT)
+					{
+						GAMETEXT.setYieldChangeHelp(szBuffer, GC.getImprovementInfo(eFinalImprovement).getDescription(), L": ", L"", GC.getImprovementInfo(eFinalImprovement).getRouteYieldChangesArray(eRoute));
+					}
+
+					iMovementCost = GC.getRouteInfo(eRoute).getMovementCost() + GET_TEAM(pHeadSelectedUnit->getTeam()).getRouteChange(eRoute);
+					iFlatMovementCost = GC.getRouteInfo(eRoute).getFlatMovementCost();
+
+					if (iMovementCost > 0)
+					{
+						iMoves = (GC.getMOVE_DENOMINATOR() / iMovementCost);
+
+						if ((iMoves * iMovementCost) < GC.getMOVE_DENOMINATOR())
+						{
+							iMoves++;
+						}
+					}
+					else
+					{
+						iMoves = GC.getMOVE_DENOMINATOR();
+					}
+
+					if (iFlatMovementCost > 0)
+					{
+						iFlatMoves = (GC.getMOVE_DENOMINATOR() / iFlatMovementCost);
+
+						if ((iFlatMoves * iFlatMovementCost) < GC.getMOVE_DENOMINATOR())
+						{
+							iFlatMoves++;
+						}
+					}
+					else
+					{
+						iFlatMoves = GC.getMOVE_DENOMINATOR();
+					}
+
+					if ((iMoves > 1) || (iFlatMoves > 1))
+					{
+						if (iMoves >= iFlatMoves)
+						{
+							szBuffer.append(NEWLINE);
+							szBuffer.append(gDLL->getText("TXT_KEY_ACTION_MOVEMENT_COST", iMoves));
+						}
+						else
+						{
+							szBuffer.append(NEWLINE);
+							szBuffer.append(gDLL->getText("TXT_KEY_ACTION_FLAT_MOVEMENT_COST", iFlatMoves));
+						}
+					}
+
+					szBuffer.append(NEWLINE);
+					szBuffer.append(gDLL->getText("TXT_KEY_ACTION_CONNECTS_RESOURCES"));
+				}
+
+				iNowWorkRate = 0;
+				iThenWorkRate = 0;
+
+				pSelectedUnitNode = gDLL->getInterfaceIFace()->headSelectionListNode();
+
+				if (NULL != pHeadSelectedUnit)
+				{
+					if (GET_PLAYER(pHeadSelectedUnit->getOwnerINLINE()).getBuildCost(pMissionPlot, eBuild) > 0)
+					{
+						szBuffer.append(NEWLINE);
+						szBuffer.append(gDLL->getText("TXT_KEY_BUILD_COST", GET_PLAYER(pHeadSelectedUnit->getOwnerINLINE()).getBuildCost(pMissionPlot, eBuild)));
+					}
+				}
+
+				while (pSelectedUnitNode != NULL)
+				{
+					pSelectedUnit = ::getUnit(pSelectedUnitNode->m_data);
+
+					if (pSelectedUnit->getBuildType() != eBuild)
+					{
+						iNowWorkRate += pSelectedUnit->workRate(false);
+						iThenWorkRate += pSelectedUnit->workRate(true);
+					}
+
+					pSelectedUnitNode = gDLL->getInterfaceIFace()->nextSelectionListNode(pSelectedUnitNode);
+				}
+
+				iTurns = pMissionPlot->getBuildTurnsLeft(eBuild, iNowWorkRate, iThenWorkRate);
+
+
+				szBuffer.append(NEWLINE);
+				szBuffer.append(gDLL->getText("TXT_KEY_ACTION_NUM_TURNS", iTurns));
+
+				if (!CvWString(GC.getBuildInfo(eBuild).getHelp()).empty())
+				{
+					szBuffer.append(CvWString::format(L"%s%s", NEWLINE, GC.getBuildInfo(eBuild).getHelp()).c_str());
+				}
+			}
+
+			if (!CvWString(GC.getMissionInfo((MissionTypes)(GC.getActionInfo(widgetDataStruct.m_iData1).getMissionType())).getHelp()).empty())
+			{
+				szBuffer.append(CvWString::format(L"%s%s", NEWLINE, GC.getMissionInfo((MissionTypes)(GC.getActionInfo(widgetDataStruct.m_iData1).getMissionType())).getHelp()).c_str());
+			}
+		}
+
+		if (GC.getActionInfo(widgetDataStruct.m_iData1).getCommandType() != NO_COMMAND)
+		{
+			if (GC.getActionInfo(widgetDataStruct.m_iData1).getCommandType() == COMMAND_PROMOTION)
+			{
+				GAMETEXT.parsePromotionHelp(szBuffer, ((PromotionTypes)(GC.getActionInfo(widgetDataStruct.m_iData1).getCommandData())));
+			}
+			else if (GC.getActionInfo(widgetDataStruct.m_iData1).getCommandType() == COMMAND_UPGRADE)
+			{
+				GAMETEXT.setBasicUnitHelp(szBuffer, ((UnitTypes)(GC.getActionInfo(widgetDataStruct.m_iData1).getCommandData())));
+
+				if (bAlt && GC.getCommandInfo((CommandTypes)(GC.getActionInfo(widgetDataStruct.m_iData1).getCommandType())).getAll())
+				{
+					iPrice = GET_PLAYER(pHeadSelectedUnit->getOwnerINLINE()).upgradeAllPrice(((UnitTypes)(GC.getActionInfo(widgetDataStruct.m_iData1).getCommandData())), pHeadSelectedUnit->getUnitType());
+				}
+				else
+				{
+					iPrice = 0;
+
+					pSelectedUnitNode = gDLL->getInterfaceIFace()->headSelectionListNode();
+
+					while (pSelectedUnitNode != NULL)
+					{
+						pSelectedUnit = ::getUnit(pSelectedUnitNode->m_data);
+
+						if (pSelectedUnit->canUpgrade(((UnitTypes)(GC.getActionInfo(widgetDataStruct.m_iData1).getCommandData())), true))
+						{
+							iPrice += pSelectedUnit->upgradePrice((UnitTypes)(GC.getActionInfo(widgetDataStruct.m_iData1).getCommandData()));
+						}
+
+						pSelectedUnitNode = gDLL->getInterfaceIFace()->nextSelectionListNode(pSelectedUnitNode);
+					}
+				}
+
+				szTempBuffer.Format(L"%s%d %c", NEWLINE, iPrice, GC.getCommerceInfo(COMMERCE_GOLD).getChar());
+				szBuffer.append(szTempBuffer);
+			}
+			else if (GC.getActionInfo(widgetDataStruct.m_iData1).getCommandType() == COMMAND_GIFT)
+			{
+				eGiftPlayer = pHeadSelectedUnit->plot()->getOwnerINLINE();
+
+				if (eGiftPlayer != NO_PLAYER)
+				{
+					szBuffer.append(NEWLINE);
+					szBuffer.append(gDLL->getText("TXT_KEY_ACTION_GOES_TO_CIV"));
+
+					szTempBuffer.Format(SETCOLR L"%s" ENDCOLR, GET_PLAYER(eGiftPlayer).getPlayerTextColorR(), GET_PLAYER(eGiftPlayer).getPlayerTextColorG(), GET_PLAYER(eGiftPlayer).getPlayerTextColorB(), GET_PLAYER(eGiftPlayer).getPlayerTextColorA(), GET_PLAYER(eGiftPlayer).getCivilizationShortDescription());
+					szBuffer.append(szTempBuffer);
+
+					pSelectedUnitNode = gDLL->getInterfaceIFace()->headSelectionListNode();
+
+					while (pSelectedUnitNode != NULL)
+					{
+						pSelectedUnit = ::getUnit(pSelectedUnitNode->m_data);
+
+						if (!(GET_PLAYER(eGiftPlayer).AI_acceptUnit(pSelectedUnit)))
+						{
+							szBuffer.append(NEWLINE);
+							szBuffer.append(gDLL->getText("TXT_KEY_REFUSE_GIFT", GET_PLAYER(eGiftPlayer).getNameKey()));
+							break;
+						}
+
+						pSelectedUnitNode = gDLL->getInterfaceIFace()->nextSelectionListNode(pSelectedUnitNode);
+					}
+				}
+			}
+
+			if (GC.getCommandInfo((CommandTypes)(GC.getActionInfo(widgetDataStruct.m_iData1).getCommandType())).getAll())
+			{
+				szBuffer.append(gDLL->getText("TXT_KEY_ACTION_ALL_UNITS"));
+			}
+
+			if (!CvWString(GC.getCommandInfo((CommandTypes)(GC.getActionInfo(widgetDataStruct.m_iData1).getCommandType())).getHelp()).empty())
+			{
+				szBuffer.append(CvWString::format(L"%s%s", NEWLINE, GC.getCommandInfo((CommandTypes)(GC.getActionInfo(widgetDataStruct.m_iData1).getCommandType())).getHelp()).c_str());
+			}
+		}
+
+		if (GC.getActionInfo(widgetDataStruct.m_iData1).getAutomateType() != NO_AUTOMATE)
+		{
+			if (!CvWString(GC.getAutomateInfo((ControlTypes)(GC.getActionInfo(widgetDataStruct.m_iData1).getAutomateType())).getHelp()).empty())
+			{
+				szBuffer.append(CvWString::format(L"%s%s", NEWLINE, GC.getAutomateInfo((ControlTypes)(GC.getActionInfo(widgetDataStruct.m_iData1).getAutomateType())).getHelp()).c_str());
+			}
+		}
+	}
+
+	if (GC.getActionInfo(widgetDataStruct.m_iData1).getControlType() != NO_CONTROL)
+	{
+		if (!CvWString(GC.getControlInfo((ControlTypes)(GC.getActionInfo(widgetDataStruct.m_iData1).getControlType())).getHelp()).empty())
+		{
+			szBuffer.append(CvWString::format(L"%s%s", NEWLINE, GC.getControlInfo((ControlTypes)(GC.getActionInfo(widgetDataStruct.m_iData1).getControlType())).getHelp()).c_str());
+		}
+	}
+
+	if (GC.getActionInfo(widgetDataStruct.m_iData1).getInterfaceModeType() != NO_INTERFACEMODE)
+	{
+		if (!CvWString(GC.getInterfaceModeInfo((InterfaceModeTypes)(GC.getActionInfo(widgetDataStruct.m_iData1).getInterfaceModeType())).getHelp()).empty())
+		{
+			szBuffer.append(CvWString::format(L"%s%s", NEWLINE, GC.getInterfaceModeInfo((InterfaceModeTypes)(GC.getActionInfo(widgetDataStruct.m_iData1).getInterfaceModeType())).getHelp()).c_str());
+		}
+	}
+}
+
+
+void CvDLLWidgetData::parseCitizenHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	CvCity* pHeadSelectedCity;
+	int iCount;
+	int iI;
+
+	pHeadSelectedCity = gDLL->getInterfaceIFace()->getHeadSelectedCity();
+
+	if (pHeadSelectedCity != NULL)
+	{
+		if (widgetDataStruct.m_iData1 != NO_SPECIALIST)
+		{
+			GAMETEXT.parseSpecialistHelp(szBuffer, ((SpecialistTypes)(widgetDataStruct.m_iData1)), pHeadSelectedCity);
+
+			if (widgetDataStruct.m_iData2 != -1)
+			{
+				iCount = 0;
+
+				for (iI = 0; iI < GC.getNumSpecialistInfos(); iI++)
+				{
+					if (iI < widgetDataStruct.m_iData1)
+					{
+						iCount += pHeadSelectedCity->getSpecialistCount((SpecialistTypes)iI);
+					}
+					else if (iI == widgetDataStruct.m_iData1)
+					{
+						iCount += widgetDataStruct.m_iData2;
+					}
+				}
+
+				if (iCount < pHeadSelectedCity->totalFreeSpecialists())
+				{
+					szBuffer.append(NEWLINE);
+					szBuffer.append(gDLL->getText("TXT_KEY_MISC_FREE_SPECIALIST"));
+				}
+			}
+		}
+	}
+}
+
+
+void CvDLLWidgetData::parseFreeCitizenHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	CvCity* pHeadSelectedCity = gDLL->getInterfaceIFace()->getHeadSelectedCity();
+
+	if (pHeadSelectedCity != NULL)
+	{
+		SpecialistTypes eSpecialist = (SpecialistTypes)widgetDataStruct.m_iData1;
+		if (NO_SPECIALIST != eSpecialist)
+		{
+			GAMETEXT.parseSpecialistHelp(szBuffer, eSpecialist, pHeadSelectedCity);
+		}
+		if (widgetDataStruct.m_iData2 != -1)
+		{
+			szBuffer.append(SEPARATOR);
+			GAMETEXT.parseFreeSpecialistHelp(szBuffer, *pHeadSelectedCity);
+		}
+	}
+}
+
+
+void CvDLLWidgetData::parseDisabledCitizenHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	CvCity* pHeadSelectedCity;
+	CvWString szTempBuffer;
+	BuildingTypes eLoopBuilding;
+	bool bFirst;
+	int iI;
+
+	pHeadSelectedCity = gDLL->getInterfaceIFace()->getHeadSelectedCity();
+
+	if (pHeadSelectedCity != NULL)
+	{
+		if (widgetDataStruct.m_iData1 != NO_SPECIALIST)
+		{
+			GAMETEXT.parseSpecialistHelp(szBuffer, ((SpecialistTypes)(widgetDataStruct.m_iData1)), pHeadSelectedCity);
+
+			if (!(pHeadSelectedCity->isSpecialistValid(((SpecialistTypes)(widgetDataStruct.m_iData1)), 1)))
+			{
+				bFirst = true;
+
+				for (iI = 0; iI < GC.getNumBuildingClassInfos(); iI++)
+				{
+					eLoopBuilding = (BuildingTypes)GC.getCivilizationInfo(GC.getGameINLINE().getActiveCivilizationType()).getCivilizationBuildings(iI);
+
+					if (eLoopBuilding != NO_BUILDING)
+					{
+						if (GC.getBuildingInfo(eLoopBuilding).getSpecialistCount(widgetDataStruct.m_iData1) > 0)
+						{
+							if ((pHeadSelectedCity->getNumBuilding(eLoopBuilding) <= 0) && !isLimitedWonderClass((BuildingClassTypes)iI))
+							{
+								if ((GC.getBuildingInfo(eLoopBuilding).getSpecialBuildingType() == NO_SPECIALBUILDING) || pHeadSelectedCity->canConstruct(eLoopBuilding))
+								{
+									szTempBuffer = NEWLINE + gDLL->getText("TXT_KEY_REQUIRES");
+									setListHelp(szBuffer, szTempBuffer, GC.getBuildingInfo(eLoopBuilding).getDescription(), gDLL->getText("TXT_KEY_OR").c_str(), bFirst);
+									bFirst = false;
+								}
+							}
+						}
+					}
+				}
+
+				if (!bFirst)
+				{
+					szBuffer.append(ENDCOLR);
+				}
+			}
+		}
+	}
+}
+
+
+void CvDLLWidgetData::parseAngryCitizenHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	CvCity* pHeadSelectedCity;
+
+	pHeadSelectedCity = gDLL->getInterfaceIFace()->getHeadSelectedCity();
+
+	if (pHeadSelectedCity != NULL)
+	{
+		szBuffer.assign(gDLL->getText("TXT_KEY_MISC_ANGRY_CITIZEN"));
+		szBuffer.append(NEWLINE);
+
+		GAMETEXT.setAngerHelp(szBuffer, *pHeadSelectedCity);
+	}
+}
+
+
+void CvDLLWidgetData::parseChangeSpecialistHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	CvCity* pHeadSelectedCity;
+
+	pHeadSelectedCity = gDLL->getInterfaceIFace()->getHeadSelectedCity();
+
+	if (pHeadSelectedCity != NULL)
+	{
+		if (widgetDataStruct.m_iData2 > 0)
+		{
+			GAMETEXT.parseSpecialistHelp(szBuffer, ((SpecialistTypes)(widgetDataStruct.m_iData1)), pHeadSelectedCity);
+
+			if (widgetDataStruct.m_iData1 != GC.getDefineINT("DEFAULT_SPECIALIST"))
+			{
+				if (!(GET_PLAYER(pHeadSelectedCity->getOwnerINLINE()).isSpecialistValid((SpecialistTypes)(widgetDataStruct.m_iData1))))
+				{
+					if (pHeadSelectedCity->getMaxSpecialistCount((SpecialistTypes)(widgetDataStruct.m_iData1)) > 0)
+					{
+						szBuffer.append(NEWLINE);
+						szBuffer.append(gDLL->getText("TXT_KEY_MISC_MAX_SPECIALISTS", pHeadSelectedCity->getMaxSpecialistCount((SpecialistTypes)(widgetDataStruct.m_iData1))));
+					}
+				}
+			}
+		}
+		else
+		{
+			szBuffer.assign(gDLL->getText("TXT_KEY_MISC_REMOVE_SPECIALIST", GC.getSpecialistInfo((SpecialistTypes) widgetDataStruct.m_iData1).getTextKeyWide()));
+
+			if (pHeadSelectedCity->getForceSpecialistCount((SpecialistTypes)(widgetDataStruct.m_iData1)) > 0)
+			{
+				szBuffer.append(NEWLINE);
+				szBuffer.append(gDLL->getText("TXT_KEY_MISC_FORCED_SPECIALIST", pHeadSelectedCity->getForceSpecialistCount((SpecialistTypes)(widgetDataStruct.m_iData1))));
+			}
+		}
+	}
+}
+
+
+void CvDLLWidgetData::parseResearchHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	TechTypes eTech;
+
+	eTech = ((TechTypes)(widgetDataStruct.m_iData1));
+
+	if (eTech == NO_TECH)
+	{
+		//	No Technology
+		if (GET_PLAYER(GC.getGameINLINE().getActivePlayer()).getCurrentResearch() != NO_TECH)
+		{
+			CvGameAI& game = GC.getGameINLINE();
+			CvPlayer& activePlayer = GET_PLAYER(game.getActivePlayer());
+			szBuffer.assign(gDLL->getText("TXT_KEY_MISC_CHANGE_RESEARCH"));
+			szBuffer.append(NEWLINE);
+			GAMETEXT.setTechHelp(szBuffer, activePlayer.getCurrentResearch(), false, true);
+		}
+	}
+	else
+	{
+		GAMETEXT.setTechHelp(szBuffer, eTech, false, true, widgetDataStruct.m_bOption);
+	}
+}
+
+
+void CvDLLWidgetData::parseTechTreeHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	GAMETEXT.setTechHelp(szBuffer, ((TechTypes)(widgetDataStruct.m_iData1)), false, false, false, false);
+}
+
+
+void CvDLLWidgetData::parseChangePercentHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	if (widgetDataStruct.m_iData2 > 0)
+	{
+		szBuffer.assign(gDLL->getText("TXT_KEY_MISC_INCREASE_RATE", GC.getCommerceInfo((CommerceTypes) widgetDataStruct.m_iData1).getTextKeyWide(), widgetDataStruct.m_iData2));
+	}
+	else
+	{
+		szBuffer.assign(gDLL->getText("TXT_KEY_MISC_DECREASE_RATE", GC.getCommerceInfo((CommerceTypes) widgetDataStruct.m_iData1).getTextKeyWide(), -(widgetDataStruct.m_iData2)));
+	}
+}
+
+
+void CvDLLWidgetData::parseContactCivHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	//	Do not execute this if we are trying to contact ourselves...
+	if (widgetDataStruct.m_iData1 >= MAX_PLAYERS || GET_PLAYER((PlayerTypes)widgetDataStruct.m_iData1).getCivilizationType() == NO_CIVILIZATION)
+	{
+		return;
+	}
+	if (GC.getGameINLINE().getActivePlayer() == widgetDataStruct.m_iData1)
+	{
+		parseScoreHelp(widgetDataStruct, szBuffer);
+		return;
+	}
+
+	szBuffer.assign(gDLL->getText("TXT_KEY_MISC_CONTACT_LEADER", GET_PLAYER((PlayerTypes)widgetDataStruct.m_iData1).getNameKey(), GET_PLAYER((PlayerTypes)widgetDataStruct.m_iData1).getCivilizationShortDescription()));
+
+	szBuffer.append(NEWLINE);
+	GAMETEXT.parsePlayerTraits(szBuffer, (PlayerTypes)widgetDataStruct.m_iData1);
+
+	if (!(GET_TEAM(GC.getGameINLINE().getActiveTeam()).isHasMet(GET_PLAYER((PlayerTypes)widgetDataStruct.m_iData1).getTeam())))
+	{
+		szBuffer.append(NEWLINE);
+		szBuffer.append(gDLL->getText("TXT_KEY_MISC_HAVENT_MET_CIV"));
+	}
+	else
+	{
+		if (!(GET_PLAYER((PlayerTypes)widgetDataStruct.m_iData1).isHuman()))
+		{
+			if (!(GET_PLAYER((PlayerTypes)widgetDataStruct.m_iData1).AI_isWillingToTalk(GC.getGameINLINE().getActivePlayer())))
+			{
+				szBuffer.append(NEWLINE);
+				szBuffer.append(gDLL->getText("TXT_KEY_MISC_REFUSES_TO_TALK"));
+			}
+
+			szBuffer.append(NEWLINE);
+			GAMETEXT.getAttitudeString(szBuffer, ((PlayerTypes)widgetDataStruct.m_iData1), GC.getGameINLINE().getActivePlayer());
+
+			szBuffer.append(NEWLINE);
+			GAMETEXT.getEspionageString(szBuffer, ((PlayerTypes)widgetDataStruct.m_iData1), GC.getGameINLINE().getActivePlayer());
+
+			szBuffer.append(gDLL->getText("TXT_KEY_MISC_CTRL_TRADE"));
+		}
+		else
+		{
+			szBuffer.append(NEWLINE);
+			GAMETEXT.getEspionageString(szBuffer, ((PlayerTypes)widgetDataStruct.m_iData1), GC.getGameINLINE().getActivePlayer());
+		}
+
+		if ((GET_PLAYER((PlayerTypes)widgetDataStruct.m_iData1).getTeam() != GC.getGameINLINE().getActiveTeam()) && !(GET_TEAM(GC.getGameINLINE().getActiveTeam()).isAtWar(GET_PLAYER((PlayerTypes)widgetDataStruct.m_iData1).getTeam())))
+		{
+			if (GET_TEAM(GC.getGameINLINE().getActiveTeam()).canDeclareWar(GET_PLAYER((PlayerTypes)widgetDataStruct.m_iData1).getTeam()))
+			{
+				szBuffer.append(NEWLINE);
+				szBuffer.append(gDLL->getText("TXT_KEY_MISC_ALT_DECLARE_WAR"));
+			}
+			else
+			{
+				szBuffer.append(NEWLINE);
+				szBuffer.append(gDLL->getText("TXT_KEY_MISC_CANNOT_DECLARE_WAR"));
+			}
+		}
+	}
+
+	if (GET_PLAYER((PlayerTypes)widgetDataStruct.m_iData1).isHuman())
+	{
+//		szBuffer += "\n(<SHIFT> to Send Chat Message)";
+		szBuffer.append(NEWLINE);
+		szBuffer.append(gDLL->getText("TXT_KEY_MISC_SHIFT_SEND_CHAT"));
+	}
+}
+
+
+void CvDLLWidgetData::parseConvertHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	if (widgetDataStruct.m_iData2 != 0)
+	{
+		if (widgetDataStruct.m_iData1 == NO_RELIGION)
+		{
+//			szBuffer.Format(L"No State %c", gDLL->getSymbolID(RELIGION_CHAR));
+			szBuffer.assign(gDLL->getText("TXT_KEY_MISC_NO_STATE_REL"));
+		}
+		else
+		{
+//			szBuffer.Format(L"Convert to %s", GC.getReligionInfo((ReligionTypes) widgetDataStruct.m_iData1).getDescription());
+			szBuffer.append(gDLL->getText("TXT_KEY_MISC_CONVERT_TO_REL", GC.getReligionInfo((ReligionTypes) widgetDataStruct.m_iData1).getTextKeyWide()));
+		}
+	}
+	else
+	{
+		GAMETEXT.setConvertHelp(szBuffer, GC.getGameINLINE().getActivePlayer(), (ReligionTypes)widgetDataStruct.m_iData1);
+	}
+}
+
+
+void CvDLLWidgetData::parseRevolutionHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	if (widgetDataStruct.m_iData1 != 0)
+	{
+//		szBuffer = "Change Civics";
+		szBuffer.assign(gDLL->getText("TXT_KEY_MISC_CHANGE_CIVICS"));
+	}
+	else
+	{
+		GAMETEXT.setRevolutionHelp(szBuffer, GC.getGameINLINE().getActivePlayer());
+	}
+}
+
+/*void CvDLLWidgetData::parsePopupQueue(CvWidgetDataStruct &widgetDataStruct, CvWString &szBuffer)
+{
+	PopupEventTypes eEvent;
+
+	if ( m_pPopup || m_pScreen )
+	{
+		if ( m_pPopup )
+		{
+			eEvent = m_pPopup->getPopupType();
+		}
+		else if ( m_pScreen )
+		{
+			eEvent = m_pScreen->getPopupType();
+		}
+
+		switch (eEvent)
+		{
+			case POPUPEVENT_NONE:
+//				szBuffer = "***NO MOUSEOVER TEXT***.  Click to activate popup.";
+				szBuffer = gDLL->getText("TXT_KEY_MISC_NO_MOUSEOVER_TEXT");
+				break;
+
+			case POPUPEVENT_PRODUCTION:
+//				szBuffer = "Production Complete";
+				szBuffer = gDLL->getText("TXT_KEY_MISC_PRODUCTION_COMPLETE");
+				break;
+
+			case POPUPEVENT_TECHNOLOGY:
+//				szBuffer = "Technology Research Complete";
+				szBuffer = gDLL->getText("TXT_KEY_MISC_TECH_RESEARCH_COMPLETE");
+				break;
+
+			case POPUPEVENT_RELIGION:
+//				szBuffer = "New Religion Discovered";
+				szBuffer = gDLL->getText("TXT_KEY_MISC_NEW_REL_DISCOVERED");
+				break;
+
+			case POPUPEVENT_WARNING:
+//				szBuffer = "Warning!!!";
+				szBuffer = gDLL->getText("TXT_KEY_MISC_WARNING");
+				break;
+
+			case POPUPEVENT_CIVIC:
+//				szBuffer = "New Civic Accessible";
+				szBuffer = gDLL->getText("TXT_KEY_MISC_NEW_CIVIC_ACCESSIBLE");
+				break;
+		}
+	}
+}*/
+
+void CvDLLWidgetData::parseAutomateCitizensHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	CvCity* pHeadSelectedCity;
+
+	pHeadSelectedCity = gDLL->getInterfaceIFace()->getHeadSelectedCity();
+
+	if (pHeadSelectedCity != NULL)
+	{
+		if (pHeadSelectedCity->isCitizensAutomated())
+		{
+//			szBuffer = "Turn Off Citizen Automation";
+			szBuffer.assign(gDLL->getText("TXT_KEY_MISC_OFF_CITIZEN_AUTO"));
+		}
+		else
+		{
+//			szBuffer = "Turn On Citizen Automation";
+			szBuffer.assign(gDLL->getText("TXT_KEY_MISC_ON_CITIZEN_AUTO"));
+		}
+	}
+}
+
+void CvDLLWidgetData::parseAutomateProductionHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	CvCity* pHeadSelectedCity;
+
+	pHeadSelectedCity = gDLL->getInterfaceIFace()->getHeadSelectedCity();
+
+	if (pHeadSelectedCity != NULL)
+	{
+		if (pHeadSelectedCity->isProductionAutomated())
+		{
+//			szBuffer = "Turn Off Production Automation";
+			szBuffer.assign(gDLL->getText("TXT_KEY_MISC_OFF_PROD_AUTO"));
+		}
+		else
+		{
+//			szBuffer = "Turn On Production Automation";
+			szBuffer.assign(gDLL->getText("TXT_KEY_MISC_ON_PROD_AUTO"));
+		}
+	}
+}
+
+void CvDLLWidgetData::parseEmphasizeHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	CvCity* pHeadSelectedCity;
+
+	szBuffer.clear();
+
+	pHeadSelectedCity = gDLL->getInterfaceIFace()->getHeadSelectedCity();
+
+	if (pHeadSelectedCity != NULL)
+	{
+		if (pHeadSelectedCity->AI_isEmphasize((EmphasizeTypes)widgetDataStruct.m_iData1))
+		{
+//			szBuffer += "Turn Off ";
+			szBuffer.append(gDLL->getText("TXT_KEY_MISC_TURN_OFF"));
+		}
+		else
+		{
+//			szBuffer += "Turn On ";
+			szBuffer.append(gDLL->getText("TXT_KEY_MISC_TURN_ON"));
+		}
+	}
+
+	szBuffer.append(GC.getEmphasizeInfo((EmphasizeTypes)widgetDataStruct.m_iData1).getDescription());
+}
+
+
+void CvDLLWidgetData::parseTradeItem(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	CvWString szTempBuffer;
+	TradeData item;
+	PlayerTypes eWhoFrom = NO_PLAYER;
+	PlayerTypes eWhoTo = NO_PLAYER;
+	DenialTypes eDenial;
+	PlayerTypes eWhoDenies;
+
+	szBuffer.clear();
+
+	if (widgetDataStruct.m_bOption)
+	{
+		if ( gDLL->isDiplomacy())
+		{
+			eWhoFrom = (PlayerTypes) gDLL->getDiplomacyPlayer();
+		}
+		else if (gDLL->isMPDiplomacyScreenUp())
+		{
+			eWhoFrom = (PlayerTypes) gDLL->getMPDiplomacyPlayer();
+		}
+		eWhoTo = GC.getGameINLINE().getActivePlayer();
+	}
+	else
+	{
+		eWhoFrom = GC.getGameINLINE().getActivePlayer();
+		if ( gDLL->isDiplomacy() )
+		{
+			eWhoTo = (PlayerTypes) gDLL->getDiplomacyPlayer();
+		}
+		else if (gDLL->isMPDiplomacyScreenUp())
+		{
+			eWhoTo = (PlayerTypes) gDLL->getMPDiplomacyPlayer();
+		}
+	}
+
+	eWhoDenies = eWhoFrom;
+
+	if ((eWhoFrom != NO_PLAYER) && (eWhoTo != NO_PLAYER))
+	{
+		//	Data1 is the heading
+		switch (widgetDataStruct.m_iData1)
+		{
+		case TRADE_TECHNOLOGIES:
+			GAMETEXT.setTechHelp(szBuffer, ((TechTypes)widgetDataStruct.m_iData2));
+			eWhoDenies = (widgetDataStruct.m_bOption ? eWhoFrom : eWhoTo);
+			break;
+		case TRADE_RESOURCES:
+			GAMETEXT.setBonusHelp(szBuffer, ((BonusTypes)widgetDataStruct.m_iData2));
+			eWhoDenies = (widgetDataStruct.m_bOption ? eWhoFrom : eWhoTo);
+			break;
+		case TRADE_CITIES:
+			szBuffer.assign(gDLL->getText("TXT_KEY_TRADE_CITIES"));
+			eWhoDenies = (widgetDataStruct.m_bOption ? eWhoFrom : eWhoTo);
+			break;
+		case TRADE_PEACE:
+			szBuffer.append(gDLL->getText("TXT_KEY_TRADE_MAKE_PEACE", GET_TEAM(GET_PLAYER(eWhoFrom).getTeam()).getName().GetCString(), GET_TEAM((TeamTypes)widgetDataStruct.m_iData2).getName().GetCString()));
+			break;
+		case TRADE_WAR:
+			szBuffer.append(gDLL->getText("TXT_KEY_TRADE_MAKE_WAR", GET_TEAM(GET_PLAYER(eWhoFrom).getTeam()).getName().GetCString(), GET_TEAM((TeamTypes)widgetDataStruct.m_iData2).getName().GetCString()));
+			break;
+		case TRADE_EMBARGO:
+			szBuffer.append(gDLL->getText("TXT_KEY_TRADE_STOP_TRADING", GET_TEAM(GET_PLAYER(eWhoFrom).getTeam()).getName().GetCString(), GET_TEAM((TeamTypes)widgetDataStruct.m_iData2).getName().GetCString()));
+			break;
+		case TRADE_CIVIC:
+			szBuffer.append(gDLL->getText("TXT_KEY_TRADE_ADOPT_CIVIC", GC.getCivicInfo((CivicTypes)widgetDataStruct.m_iData2).getDescription()));
+			break;
+		case TRADE_RELIGION:
+			szBuffer.append(gDLL->getText("TXT_KEY_TRADE_CONVERT_RELIGION", GC.getReligionInfo((ReligionTypes)widgetDataStruct.m_iData2).getDescription()));
+			break;
+		case TRADE_GOLD:
+			szBuffer.append(gDLL->getText("TXT_KEY_TRADE_GOLD"));
+			break;
+		case TRADE_GOLD_PER_TURN:
+			szBuffer.append(gDLL->getText("TXT_KEY_TRADE_GOLD_PER_TURN"));
+			break;
+		case TRADE_MAPS:
+			szBuffer.append(gDLL->getText("TXT_KEY_TRADE_MAPS"));
+			break;
+		case TRADE_SURRENDER:
+			szBuffer.append(gDLL->getText("TXT_KEY_TRADE_CAPITULATE"));
+			break;
+		case TRADE_VASSAL:
+			szBuffer.append(gDLL->getText("TXT_KEY_TRADE_VASSAL"));
+			break;
+		case TRADE_OPEN_BORDERS:
+			szBuffer.append(gDLL->getText("TXT_KEY_TRADE_OPEN_BORDERS"));
+			break;
+		case TRADE_DEFENSIVE_PACT:
+			szBuffer.append(gDLL->getText("TXT_KEY_TRADE_DEFENSIVE_PACT"));
+			break;
+		case TRADE_PERMANENT_ALLIANCE:
+			szBuffer.append(gDLL->getText("TXT_KEY_TRADE_PERMANENT_ALLIANCE"));
+			break;
+		case TRADE_PEACE_TREATY:
+			szBuffer.append(gDLL->getText("TXT_KEY_TRADE_PEACE_TREATY", GC.getDefineINT("PEACE_TREATY_LENGTH")));
+			break;
+		}
+
+		setTradeItem(&item, ((TradeableItems)(widgetDataStruct.m_iData1)), widgetDataStruct.m_iData2);
+
+		eDenial = GET_PLAYER(eWhoFrom).getTradeDenial(eWhoTo, item);
+
+		if (eDenial != NO_DENIAL)
+		{
+			szTempBuffer.Format(L"%s: " SETCOLR L"%s" ENDCOLR, GET_PLAYER(eWhoDenies).getName(), TEXT_COLOR("COLOR_WARNING_TEXT"), GC.getDenialInfo(eDenial).getDescription());
+			szBuffer.append(NEWLINE);
+			szBuffer.append(szTempBuffer);
+		}
+	}
+}
+
+
+void CvDLLWidgetData::parseUnitModelHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	CvUnit* pHeadSelectedUnit;
+
+	pHeadSelectedUnit = gDLL->getInterfaceIFace()->getHeadSelectedUnit();
+
+	if (pHeadSelectedUnit != NULL)
+	{
+		GAMETEXT.setUnitHelp(szBuffer, pHeadSelectedUnit);
+	}
+}
+
+
+void CvDLLWidgetData::parseFlagHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	CvWString szTempBuffer;
+
+	szTempBuffer.Format(SETCOLR L"%s" ENDCOLR, TEXT_COLOR("COLOR_HIGHLIGHT_TEXT"), GC.getCivilizationInfo(GC.getGameINLINE().getActiveCivilizationType()).getDescription());
+	szBuffer.append(szTempBuffer);
+	szBuffer.append(NEWLINE);
+
+	GAMETEXT.parseLeaderTraits(szBuffer, GET_PLAYER(GC.getGameINLINE().getActivePlayer()).getLeaderType(), GET_PLAYER(GC.getGameINLINE().getActivePlayer()).getCivilizationType());
+}
+
+
+void CvDLLWidgetData::parseMaintenanceHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	CvCity* pHeadSelectedCity;
+	wchar szTempBuffer[1024];
+	int iMaintenanceValue;
+
+	pHeadSelectedCity = gDLL->getInterfaceIFace()->getHeadSelectedCity();
+
+	if (pHeadSelectedCity != NULL)
+	{
+		if (pHeadSelectedCity->isWeLoveTheKingDay())
+		{
+			szBuffer.append(NEWLINE);
+			szBuffer.append(gDLL->getText("TXT_KEY_MISC_WE_LOVE_KING_MAINT"));
+		}
+		else
+		{
+			//		szBuffer = "Maintenance represents the total cost of governing this city.\n";
+			szBuffer.assign(gDLL->getText("TXT_KEY_MISC_MAINT_INFO"));
+			szBuffer.append(NEWLINE);
+
+			iMaintenanceValue = pHeadSelectedCity->calculateDistanceMaintenanceTimes100();
+			if (iMaintenanceValue != 0)
+			{
+				//			swprintf(szTempBuffer, "\n%s%d%c: %s", ((iMaintenanceValue > 0) ?  "+" : ""), iMaintenanceValue, GC.getCommerceInfo(COMMERCE_GOLD).getChar(), ((GET_PLAYER(pHeadSelectedCity->getOwnerINLINE()).getNumGovernmentCenters() > 0) ? "Distance from Palace" : "No Palace Penalty"));
+				CvWString szMaint = CvWString::format(L"%d.%02d", iMaintenanceValue/100, iMaintenanceValue%100);
+				szBuffer.append(NEWLINE);
+				szBuffer.append(gDLL->getText("TXT_KEY_MISC_NUM_MAINT_FLOAT", szMaint.GetCString()) + ((GET_PLAYER(pHeadSelectedCity->getOwnerINLINE()).getNumGovernmentCenters() > 0) ? gDLL->getText("TXT_KEY_MISC_DISTANCE_FROM_PALACE") : gDLL->getText("TXT_KEY_MISC_NO_PALACE_PENALTY")));
+			}
+
+			iMaintenanceValue = pHeadSelectedCity->calculateNumCitiesMaintenanceTimes100();
+			if (iMaintenanceValue != 0)
+			{
+				//			swprintf(szTempBuffer, "\n%s%d%c: Number of Cities", ((iMaintenanceValue > 0) ? "+" : ""), iMaintenanceValue, GC.getCommerceInfo(COMMERCE_GOLD).getChar());
+				CvWString szMaint = CvWString::format(L"%d.%02d", iMaintenanceValue/100, iMaintenanceValue%100);
+				szBuffer.append(NEWLINE);
+				szBuffer.append(gDLL->getText("TXT_KEY_MISC_NUM_CITIES_FLOAT", szMaint.GetCString()));
+			}
+
+			iMaintenanceValue = pHeadSelectedCity->calculateColonyMaintenanceTimes100();
+			if (iMaintenanceValue != 0)
+			{
+				CvWString szMaint = CvWString::format(L"%d.%02d", iMaintenanceValue/100, iMaintenanceValue%100);
+				szBuffer.append(NEWLINE);
+				szBuffer.append(gDLL->getText("TXT_KEY_MISC_COLONY_MAINT_FLOAT", szMaint.GetCString()));
+			}
+
+			iMaintenanceValue = pHeadSelectedCity->calculateCorporationMaintenanceTimes100();
+			if (iMaintenanceValue != 0)
+			{
+				CvWString szMaint = CvWString::format(L"%d.%02d", iMaintenanceValue/100, iMaintenanceValue%100);
+				szBuffer.append(NEWLINE);
+				szBuffer.append(gDLL->getText("TXT_KEY_MISC_CORPORATION_MAINT_FLOAT", szMaint.GetCString()));
+			}
+
+			szBuffer.append(SEPARATOR);
+
+			//		swprintf(szTempBuffer, "\n%d%c Total Maintenance", pHeadSelectedCity->getMaintenance(), GC.getCommerceInfo(COMMERCE_GOLD).getChar());
+			CvWString szMaint = CvWString::format(L"%d.%02d", pHeadSelectedCity->getMaintenanceTimes100()/100, pHeadSelectedCity->getMaintenanceTimes100()%100);
+			szBuffer.append(NEWLINE);
+			szBuffer.append(gDLL->getText("TXT_KEY_MISC_TOTAL_MAINT_FLOAT", szMaint.GetCString()));
+
+			iMaintenanceValue = pHeadSelectedCity->getMaintenanceModifier();
+
+			if (iMaintenanceValue != 0)
+			{
+				swprintf(szTempBuffer, L" (%s%d%%)", ((iMaintenanceValue > 0) ? L"+" : L""), iMaintenanceValue);
+				szBuffer.append(szTempBuffer);
+			}
+		}
+	}
+}
+
+
+void CvDLLWidgetData::parseHealthHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	CvCity* pHeadSelectedCity = gDLL->getInterfaceIFace()->getHeadSelectedCity();
+	if (NULL != pHeadSelectedCity)
+	{
+		GAMETEXT.setBadHealthHelp(szBuffer, *pHeadSelectedCity);
+		szBuffer.append(L"\n=======================\n");
+		GAMETEXT.setGoodHealthHelp(szBuffer, *pHeadSelectedCity);
+	}
+}
+
+
+void CvDLLWidgetData::parseNationalityHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	wchar szTempBuffer[1024];
+	CvCity* pHeadSelectedCity;
+	PlayerTypes eCulturalOwner;
+	int iCulturePercent;
+	int iCityStrength;
+	int iGarrison;
+	int iI;
+
+	szBuffer.assign(gDLL->getText("TXT_KEY_MISC_CITY_NATIONALITY"));
+
+	pHeadSelectedCity = gDLL->getInterfaceIFace()->getHeadSelectedCity();
+
+	if (pHeadSelectedCity != NULL)
+	{
+		for (iI = 0; iI < MAX_PLAYERS; iI++)
+		{
+			if (GET_PLAYER((PlayerTypes)iI).isAlive())
+			{
+				iCulturePercent = pHeadSelectedCity->plot()->calculateCulturePercent((PlayerTypes)iI);
+
+				if (iCulturePercent > 0)
+				{
+					swprintf(szTempBuffer, L"\n%d%% " SETCOLR L"%s" ENDCOLR, iCulturePercent, GET_PLAYER((PlayerTypes)iI).getPlayerTextColorR(), GET_PLAYER((PlayerTypes)iI).getPlayerTextColorG(), GET_PLAYER((PlayerTypes)iI).getPlayerTextColorB(), GET_PLAYER((PlayerTypes)iI).getPlayerTextColorA(), GET_PLAYER((PlayerTypes)iI).getCivilizationAdjective());
+					szBuffer.append(szTempBuffer);
+				}
+			}
+		}
+
+		eCulturalOwner = pHeadSelectedCity->plot()->calculateCulturalOwner();
+
+		if (eCulturalOwner != NO_PLAYER)
+		{
+			if (GET_PLAYER(eCulturalOwner).getTeam() != pHeadSelectedCity->getTeam())
+			{
+				iCityStrength = pHeadSelectedCity->cultureStrength(eCulturalOwner);
+				iGarrison = pHeadSelectedCity->cultureGarrison(eCulturalOwner);
+
+				if (iCityStrength > iGarrison)
+				{
+					swprintf(szTempBuffer, L"%.2f", std::max(0.0f, (1.0f - (((float)iGarrison) / ((float)iCityStrength)))) * ((float)(std::min(100.0f, ((float)pHeadSelectedCity->getRevoltTestProbability())))));
+					szBuffer.append(NEWLINE);
+					szBuffer.append(gDLL->getText("TXT_KEY_MISC_CHANCE_OF_REVOLT", szTempBuffer));
+				}
+			}
+		}
+	}
+}
+
+
+void CvDLLWidgetData::parseHappinessHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	CvCity* pHeadSelectedCity;
+
+	pHeadSelectedCity = gDLL->getInterfaceIFace()->getHeadSelectedCity();
+
+	if (pHeadSelectedCity != NULL)
+	{
+		GAMETEXT.setAngerHelp(szBuffer, *pHeadSelectedCity);
+		szBuffer.append(L"\n=======================\n");
+		GAMETEXT.setHappyHelp(szBuffer, *pHeadSelectedCity);
+	}
+}
+
+
+void CvDLLWidgetData::parsePopulationHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	CvCity* pHeadSelectedCity;
+
+	pHeadSelectedCity = gDLL->getInterfaceIFace()->getHeadSelectedCity();
+
+	if (pHeadSelectedCity != NULL)
+	{
+		szBuffer.assign(gDLL->getText("TXT_KEY_MISC_FOOD_THRESHOLD", pHeadSelectedCity->getFood(), pHeadSelectedCity->growthThreshold()));
+	}
+}
+
+
+void CvDLLWidgetData::parseProductionHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	CvCity* pHeadSelectedCity;
+
+	pHeadSelectedCity = gDLL->getInterfaceIFace()->getHeadSelectedCity();
+
+	if (pHeadSelectedCity != NULL)
+	{
+		if (pHeadSelectedCity->getProductionNeeded() != MAX_INT)
+		{
+			CvWString szTemp;
+			szTemp.Format(L"%s: %d/%d %c", pHeadSelectedCity->getProductionName(), pHeadSelectedCity->getProduction(), pHeadSelectedCity->getProductionNeeded(), GC.getYieldInfo(YIELD_PRODUCTION).getChar());
+			szBuffer.assign(szTemp);
+		}
+	}
+}
+
+
+void CvDLLWidgetData::parseCultureHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	CvCity* pHeadSelectedCity;
+
+	pHeadSelectedCity = gDLL->getInterfaceIFace()->getHeadSelectedCity();
+
+	if (pHeadSelectedCity != NULL)
+	{
+		int iCultureTimes100 = pHeadSelectedCity->getCultureTimes100(pHeadSelectedCity->getOwnerINLINE());
+		if (iCultureTimes100%100 == 0)
+		{
+			szBuffer.assign(gDLL->getText("TXT_KEY_MISC_CULTURE", iCultureTimes100/100, pHeadSelectedCity->getCultureThreshold()));
+		}
+		else
+		{
+			CvWString szCulture = CvWString::format(L"%d.%02d", iCultureTimes100/100, iCultureTimes100%100);
+			szBuffer.assign(gDLL->getText("TXT_KEY_MISC_CULTURE_FLOAT", szCulture.GetCString(), pHeadSelectedCity->getCultureThreshold()));
+		}
+
+		int iCultureRateTimes100 = pHeadSelectedCity->getCommerceRateTimes100(COMMERCE_CULTURE);
+		if (iCultureRateTimes100 > 0)
+		{
+			int iCultureLeftTimes100 = 100 * pHeadSelectedCity->getCultureThreshold() - iCultureTimes100;
+
+			if (iCultureLeftTimes100 > 0)
+			{
+				int iTurnsLeft = (iCultureLeftTimes100  + iCultureRateTimes100 - 1) / iCultureRateTimes100;
+
+				szBuffer.append(L' ');
+				szBuffer.append(gDLL->getText("INTERFACE_CITY_TURNS", std::max(1, iTurnsLeft)));
+			}
+		}
+
+
+		szBuffer.append(L"\n=======================\n");
+		GAMETEXT.setCommerceHelp(szBuffer, *pHeadSelectedCity, COMMERCE_CULTURE);
+	}
+}
+
+
+void CvDLLWidgetData::parseGreatPeopleHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	CvCity* pHeadSelectedCity = gDLL->getInterfaceIFace()->getHeadSelectedCity();
+	if (NULL != pHeadSelectedCity)
+	{
+		GAMETEXT.parseGreatPeopleHelp(szBuffer, *pHeadSelectedCity);
+	}
+}
+
+
+void CvDLLWidgetData::parseGreatGeneralHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	if (NO_PLAYER != GC.getGame().getActivePlayer())
+	{
+		GAMETEXT.parseGreatGeneralHelp(szBuffer, GET_PLAYER(GC.getGame().getActivePlayer()));
+	}
+}
+
+
+void CvDLLWidgetData::parseSelectedHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	CvCity* pHeadSelectedCity;
+	CvUnit* pHeadSelectedUnit;
+	OrderData* pOrder;
+
+	pHeadSelectedCity = gDLL->getInterfaceIFace()->getHeadSelectedCity();
+	pHeadSelectedUnit = gDLL->getInterfaceIFace()->getHeadSelectedUnit();
+
+	if (pHeadSelectedCity != NULL)
+	{
+		pOrder = pHeadSelectedCity->getOrderFromQueue(widgetDataStruct.m_iData1);
+
+		if (pOrder != NULL)
+		{
+			switch (pOrder->eOrderType)
+			{
+			case ORDER_TRAIN:
+				GAMETEXT.setUnitHelp(szBuffer, ((UnitTypes)(pOrder->iData1)), false, false, false, pHeadSelectedCity);
+				break;
+
+			case ORDER_CONSTRUCT:
+				GAMETEXT.setBuildingHelp(szBuffer, ((BuildingTypes)(pOrder->iData1)), false, false, false, pHeadSelectedCity);
+				break;
+
+			case ORDER_CREATE:
+				GAMETEXT.setProjectHelp(szBuffer, ((ProjectTypes)(pOrder->iData1)), false, pHeadSelectedCity);
+				break;
+
+			case ORDER_MAINTAIN:
+				GAMETEXT.setProcessHelp(szBuffer, ((ProcessTypes)(pOrder->iData1)));
+				break;
+
+			default:
+				FAssertMsg(false, "eOrderType did not match valid options");
+				break;
+			}
+		}
+	}
+}
+
+
+void CvDLLWidgetData::parseTradeRouteCityHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	if (widgetDataStruct.m_iData2 != 0)
+	{
+		GAMETEXT.setTradeRouteHelp(szBuffer, widgetDataStruct.m_iData1, gDLL->getInterfaceIFace()->getHeadSelectedCity());
+	}
+}
+
+void CvDLLWidgetData::parseEspionageCostHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	CvUnit* pUnit = gDLL->getInterfaceIFace()->getHeadSelectedUnit();
+	if (NULL != pUnit)
+	{
+		CvPlot* pPlot = pUnit->plot();
+		if (NULL != pPlot)
+		{
+			GAMETEXT.setEspionageCostHelp(szBuffer, (EspionageMissionTypes)widgetDataStruct.m_iData1, pPlot->getOwnerINLINE(), pPlot, widgetDataStruct.m_iData2, pUnit);
+		}
+	}
+}
+
+void CvDLLWidgetData::parseBuildingHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	if (widgetDataStruct.m_iData2 != 0)
+	{
+		GAMETEXT.setBuildingHelp(szBuffer, ((BuildingTypes)(widgetDataStruct.m_iData1)), false, false, widgetDataStruct.m_bOption, gDLL->getInterfaceIFace()->getHeadSelectedCity());
+	}
+}
+
+void CvDLLWidgetData::parseProjectHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	if (widgetDataStruct.m_iData2 != 0)
+	{
+		GAMETEXT.setProjectHelp(szBuffer, ((ProjectTypes)widgetDataStruct.m_iData1), false, gDLL->getInterfaceIFace()->getHeadSelectedCity());
+	}
+}
+
+
+void CvDLLWidgetData::parseTerrainHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	if (widgetDataStruct.m_iData2 != 0)
+	{
+		GAMETEXT.setTerrainHelp(szBuffer, (TerrainTypes)widgetDataStruct.m_iData1);
+	}
+}
+
+
+void CvDLLWidgetData::parseFeatureHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	if (widgetDataStruct.m_iData2 != 0)
+	{
+		GAMETEXT.setFeatureHelp(szBuffer, (FeatureTypes)widgetDataStruct.m_iData1);
+	}
+}
+
+
+void CvDLLWidgetData::parseTechEntryHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	if (widgetDataStruct.m_iData2 != 0)
+	{
+		GAMETEXT.setTechHelp(szBuffer, ((TechTypes)(widgetDataStruct.m_iData1)));
+	}
+}
+
+
+void CvDLLWidgetData::parseTechPrereqHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+//	szBuffer.Format(L"%cThis technology requires the knowledge of %s", gDLL->getSymbolID(BULLET_CHAR), GC.getTechInfo((TechTypes) widgetDataStruct.m_iData1).getDescription());
+	szBuffer.assign(gDLL->getText("TXT_KEY_MISC_TECH_REQUIRES_KNOWLEDGE_OF", GC.getTechInfo((TechTypes) widgetDataStruct.m_iData1).getTextKeyWide()));
+}
+
+void CvDLLWidgetData::parseTechTreePrereq(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer, bool bTreeInfo)
+{
+	GAMETEXT.setTechHelp(szBuffer, (TechTypes)widgetDataStruct.m_iData1, false, false, false, bTreeInfo, (TechTypes)widgetDataStruct.m_iData2);
+}
+
+
+void CvDLLWidgetData::parseObsoleteHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	GAMETEXT.buildObsoleteString(szBuffer, ((TechTypes)(widgetDataStruct.m_iData1)));
+}
+
+void CvDLLWidgetData::parseObsoleteBonusString(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	GAMETEXT.buildObsoleteBonusString(szBuffer, ((BonusTypes)(widgetDataStruct.m_iData1)));
+}
+
+void CvDLLWidgetData::parseObsoleteSpecialHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	GAMETEXT.buildObsoleteSpecialString(szBuffer, ((TechTypes)(widgetDataStruct.m_iData1)));
+}
+
+void CvDLLWidgetData::parseMoveHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	GAMETEXT.buildMoveString(szBuffer, ((TechTypes)(widgetDataStruct.m_iData1)));
+}
+
+void CvDLLWidgetData::parseFreeUnitHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	GAMETEXT.buildFreeUnitString(szBuffer, ((TechTypes)(widgetDataStruct.m_iData2)));
+}
+
+void CvDLLWidgetData::parseFeatureProductionHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	GAMETEXT.buildFeatureProductionString(szBuffer, ((TechTypes)(widgetDataStruct.m_iData1)));
+}
+
+void CvDLLWidgetData::parseWorkerRateHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	GAMETEXT.buildWorkerRateString(szBuffer, ((TechTypes)(widgetDataStruct.m_iData1)));
+}
+
+void CvDLLWidgetData::parseTradeRouteHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	GAMETEXT.buildTradeRouteString(szBuffer, ((TechTypes)(widgetDataStruct.m_iData1)));
+}
+
+void CvDLLWidgetData::parseHealthRateHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	GAMETEXT.buildHealthRateString(szBuffer, ((TechTypes)(widgetDataStruct.m_iData1)));
+}
+
+void CvDLLWidgetData::parseHappinessRateHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	GAMETEXT.buildHappinessRateString(szBuffer, ((TechTypes)(widgetDataStruct.m_iData1)));
+}
+
+void CvDLLWidgetData::parseFreeTechHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	GAMETEXT.buildFreeTechString(szBuffer, ((TechTypes)(widgetDataStruct.m_iData1)));
+}
+
+void CvDLLWidgetData::parseLOSHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	GAMETEXT.buildLOSString(szBuffer, ((TechTypes)(widgetDataStruct.m_iData1)));
+}
+
+void CvDLLWidgetData::parseMapCenterHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	GAMETEXT.buildMapCenterString(szBuffer, ((TechTypes)(widgetDataStruct.m_iData1)));
+}
+
+void CvDLLWidgetData::parseMapRevealHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	GAMETEXT.buildMapRevealString(szBuffer, ((TechTypes)(widgetDataStruct.m_iData1)));
+}
+
+void CvDLLWidgetData::parseMapTradeHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	GAMETEXT.buildMapTradeString(szBuffer, ((TechTypes)(widgetDataStruct.m_iData1)));
+}
+
+void CvDLLWidgetData::parseTechTradeHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	GAMETEXT.buildTechTradeString(szBuffer, ((TechTypes)(widgetDataStruct.m_iData1)));
+}
+
+void CvDLLWidgetData::parseGoldTradeHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	GAMETEXT.buildGoldTradeString(szBuffer, ((TechTypes)(widgetDataStruct.m_iData1)));
+}
+
+void CvDLLWidgetData::parseOpenBordersHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	GAMETEXT.buildOpenBordersString(szBuffer, ((TechTypes)(widgetDataStruct.m_iData1)));
+}
+
+void CvDLLWidgetData::parseDefensivePactHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	GAMETEXT.buildDefensivePactString(szBuffer, ((TechTypes)(widgetDataStruct.m_iData1)));
+}
+
+void CvDLLWidgetData::parsePermanentAllianceHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	GAMETEXT.buildPermanentAllianceString(szBuffer, ((TechTypes)(widgetDataStruct.m_iData1)));
+}
+
+void CvDLLWidgetData::parseVassalStateHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	GAMETEXT.buildVassalStateString(szBuffer, ((TechTypes)(widgetDataStruct.m_iData1)));
+}
+
+void CvDLLWidgetData::parseBuildBridgeHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	GAMETEXT.buildBridgeString(szBuffer, ((TechTypes)(widgetDataStruct.m_iData1)));
+}
+
+void CvDLLWidgetData::parseIrrigationHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	GAMETEXT.buildIrrigationString(szBuffer, ((TechTypes)(widgetDataStruct.m_iData1)));
+}
+
+void CvDLLWidgetData::parseIgnoreIrrigationHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	GAMETEXT.buildIgnoreIrrigationString(szBuffer, ((TechTypes)(widgetDataStruct.m_iData1)));
+}
+
+void CvDLLWidgetData::parseWaterWorkHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	GAMETEXT.buildWaterWorkString(szBuffer, ((TechTypes)(widgetDataStruct.m_iData1)));
+}
+
+void CvDLLWidgetData::parseBuildHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	GAMETEXT.buildImprovementString(szBuffer, ((TechTypes)(widgetDataStruct.m_iData1)), widgetDataStruct.m_iData2);
+}
+
+void CvDLLWidgetData::parseDomainExtraMovesHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	GAMETEXT.buildDomainExtraMovesString(szBuffer, ((TechTypes)(widgetDataStruct.m_iData1)), widgetDataStruct.m_iData2);
+}
+
+void CvDLLWidgetData::parseAdjustHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	GAMETEXT.buildAdjustString(szBuffer, ((TechTypes)(widgetDataStruct.m_iData1)), widgetDataStruct.m_iData2);
+}
+
+void CvDLLWidgetData::parseTerrainTradeHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	if (widgetDataStruct.m_iData2 < GC.getNumTerrainInfos())
+	{
+		GAMETEXT.buildTerrainTradeString(szBuffer, ((TechTypes)(widgetDataStruct.m_iData1)), widgetDataStruct.m_iData2);
+	}
+	else if (widgetDataStruct.m_iData2 == GC.getNumTerrainInfos())
+	{
+		GAMETEXT.buildRiverTradeString(szBuffer, ((TechTypes)(widgetDataStruct.m_iData1)));
+	}
+}
+
+void CvDLLWidgetData::parseSpecialBuildingHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	GAMETEXT.buildSpecialBuildingString(szBuffer, ((TechTypes)(widgetDataStruct.m_iData1)), widgetDataStruct.m_iData2);
+}
+
+void CvDLLWidgetData::parseYieldChangeHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	GAMETEXT.buildYieldChangeString(szBuffer, ((TechTypes)(widgetDataStruct.m_iData1)), widgetDataStruct.m_iData2, false);
+}
+
+void CvDLLWidgetData::parseBonusRevealHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	GAMETEXT.buildBonusRevealString(szBuffer, ((TechTypes)(widgetDataStruct.m_iData1)), widgetDataStruct.m_iData2, true);
+}
+
+void CvDLLWidgetData::parseCivicRevealHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	GAMETEXT.buildCivicRevealString(szBuffer, ((TechTypes)(widgetDataStruct.m_iData1)), widgetDataStruct.m_iData2, true);
+}
+
+void CvDLLWidgetData::parseProcessInfoHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	GAMETEXT.buildProcessInfoString(szBuffer, ((TechTypes)(widgetDataStruct.m_iData1)), widgetDataStruct.m_iData2, true);
+}
+
+void CvDLLWidgetData::parseFoundReligionHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	GAMETEXT.buildFoundReligionString(szBuffer, ((TechTypes)(widgetDataStruct.m_iData1)), widgetDataStruct.m_iData2, true);
+}
+
+void CvDLLWidgetData::parseFoundCorporationHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	GAMETEXT.buildFoundCorporationString(szBuffer, ((TechTypes)(widgetDataStruct.m_iData1)), widgetDataStruct.m_iData2, true);
+}
+
+void CvDLLWidgetData::parseFinanceNumUnits(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+//	szBuffer = "Number of units you are currently supporting";
+	szBuffer.assign(gDLL->getText("TXT_KEY_ECON_NUM_UNITS_SUPPORTING"));
+}
+
+void CvDLLWidgetData::parseFinanceUnitCost(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+//	szBuffer = "The amount of money spent on unit upkeep";
+	szBuffer.assign(gDLL->getText("TXT_KEY_ECON_MONEY_SPENT_UPKEEP"));
+	if (widgetDataStruct.m_iData2 > 0)
+	{
+		GAMETEXT.buildFinanceUnitCostString(szBuffer, (PlayerTypes)widgetDataStruct.m_iData1);
+	}
+}
+
+void CvDLLWidgetData::parseFinanceAwaySupply(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+//	szBuffer = "The amount of money spent on units in enemy territory";
+	szBuffer.assign(gDLL->getText("TXT_KEY_ECON_AMOUNT_MONEY_UNITS_ENEMY_TERRITORY"));
+	if (widgetDataStruct.m_iData2 > 0)
+	{
+		GAMETEXT.buildFinanceAwaySupplyString(szBuffer, (PlayerTypes)widgetDataStruct.m_iData1);
+	}
+}
+
+void CvDLLWidgetData::parseFinanceCityMaint(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+//	szBuffer = "The amount of money spent doing city maintenance";
+	szBuffer.assign(gDLL->getText("TXT_KEY_ECON_AMOUNT_MONEY_CITY_MAINT"));
+	if (widgetDataStruct.m_iData2 > 0)
+	{
+		GAMETEXT.buildFinanceCityMaintString(szBuffer, (PlayerTypes)widgetDataStruct.m_iData1);
+	}
+}
+
+void CvDLLWidgetData::parseFinanceCivicUpkeep(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+//	szBuffer = "The amount of money spent on Civics";
+	szBuffer.assign(gDLL->getText("TXT_KEY_ECON_AMOUNT_MONEY_CIVIC_UPKEEP"));
+	if (widgetDataStruct.m_iData2 > 0)
+	{
+		GAMETEXT.buildFinanceCivicUpkeepString(szBuffer, (PlayerTypes)widgetDataStruct.m_iData1);
+	}
+}
+
+void CvDLLWidgetData::parseFinanceForeignIncome(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	szBuffer.assign(gDLL->getText("TXT_KEY_ECON_AMOUNT_MONEY_FOREIGN"));
+	if (widgetDataStruct.m_iData2 > 0)
+	{
+		GAMETEXT.buildFinanceForeignIncomeString(szBuffer, (PlayerTypes)widgetDataStruct.m_iData1);
+	}
+}
+
+void CvDLLWidgetData::parseFinanceInflatedCosts(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	szBuffer.assign(gDLL->getText("TXT_KEY_ECON_AMOUNT_MONEY_AFTER_INFLATION"));
+	if (widgetDataStruct.m_iData2 > 0)
+	{
+		GAMETEXT.buildFinanceInflationString(szBuffer, (PlayerTypes)widgetDataStruct.m_iData1);
+	}
+}
+
+void CvDLLWidgetData::parseFinanceGrossIncome(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+//	szBuffer = "Your gross income";
+	szBuffer.assign(gDLL->getText("TXT_KEY_ECON_GROSS_INCOME"));
+}
+
+void CvDLLWidgetData::parseFinanceNetGold(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+//	szBuffer = "Net Gold per turn";
+	szBuffer.assign(gDLL->getText("TXT_KEY_ECON_NET_GOLD"));
+}
+
+void CvDLLWidgetData::parseFinanceGoldReserve(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+//	szBuffer = "Amount of money in your gold reserves";
+	szBuffer.assign(gDLL->getText("TXT_KEY_ECON_GOLD_RESERVE"));
+}
+
+void CvDLLWidgetData::parseUnitHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	if (widgetDataStruct.m_iData2 != 0)
+	{
+		GAMETEXT.setUnitHelp(szBuffer, (UnitTypes)widgetDataStruct.m_iData1, false, false, widgetDataStruct.m_bOption, gDLL->getInterfaceIFace()->getHeadSelectedCity());
+	}
+}
+
+void CvDLLWidgetData::parsePediaBack(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+//	szBuffer = "Back";
+	szBuffer.assign(gDLL->getText("TXT_KEY_MISC_PEDIA_BACK"));
+}
+
+void CvDLLWidgetData::parsePediaForward(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+//	szBuffer = "Forward";
+	szBuffer.assign(gDLL->getText("TXT_KEY_MISC_PEDIA_FORWARD"));
+}
+
+void CvDLLWidgetData::parseBonusHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	if (widgetDataStruct.m_iData2 != 0)
+	{
+		GAMETEXT.setBonusHelp(szBuffer, (BonusTypes)widgetDataStruct.m_iData1);
+	}
+}
+
+void CvDLLWidgetData::parseReligionHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	if (widgetDataStruct.m_iData2 != 0)
+	{
+		GAMETEXT.setReligionHelp(szBuffer, (ReligionTypes)widgetDataStruct.m_iData1);
+	}
+}
+
+void CvDLLWidgetData::parseReligionHelpCity( CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer )
+{
+	GAMETEXT.setReligionHelpCity(szBuffer, (ReligionTypes)widgetDataStruct.m_iData1, gDLL->getInterfaceIFace()->getHeadSelectedCity(), true);
+}
+
+void CvDLLWidgetData::parseCorporationHelpCity( CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer )
+{
+	GAMETEXT.setCorporationHelpCity(szBuffer, (CorporationTypes)widgetDataStruct.m_iData1, gDLL->getInterfaceIFace()->getHeadSelectedCity(), true);
+}
+
+void CvDLLWidgetData::parseCorporationHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	if (widgetDataStruct.m_iData2 != 0)
+	{
+		GAMETEXT.setCorporationHelp(szBuffer, (CorporationTypes)widgetDataStruct.m_iData1);
+	}
+}
+
+void CvDLLWidgetData::parsePromotionHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	if (widgetDataStruct.m_iData2 != 0)
+	{
+		GAMETEXT.setPromotionHelp(szBuffer, (PromotionTypes)widgetDataStruct.m_iData1);
+	}
+}
+
+void CvDLLWidgetData::parseEventHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	GAMETEXT.setEventHelp(szBuffer, (EventTypes)widgetDataStruct.m_iData1, widgetDataStruct.m_iData2, GC.getGameINLINE().getActivePlayer());
+}
+
+void CvDLLWidgetData::parseUnitCombatHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	if (widgetDataStruct.m_iData2 != 0)
+	{
+		GAMETEXT.setUnitCombatHelp(szBuffer, (UnitCombatTypes)widgetDataStruct.m_iData1);
+	}
+}
+
+void CvDLLWidgetData::parseImprovementHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	if (widgetDataStruct.m_iData2 != 0)
+	{
+		GAMETEXT.setImprovementHelp(szBuffer, (ImprovementTypes)widgetDataStruct.m_iData1);
+	}
+}
+
+void CvDLLWidgetData::parseCivicHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	if (widgetDataStruct.m_iData2 != 0)
+	{
+		GAMETEXT.parseCivicInfo(szBuffer, (CivicTypes)widgetDataStruct.m_iData1);
+	}
+}
+
+void CvDLLWidgetData::parseCivilizationHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	if (widgetDataStruct.m_iData2 != 0)
+	{
+		GAMETEXT.parseCivInfos(szBuffer, (CivilizationTypes)widgetDataStruct.m_iData1);
+	}
+}
+
+void CvDLLWidgetData::parseLeaderHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	if (widgetDataStruct.m_iData2 != -1)
+	{
+		GAMETEXT.parseLeaderTraits(szBuffer, (LeaderHeadTypes)widgetDataStruct.m_iData1, (CivilizationTypes)widgetDataStruct.m_iData2);
+	}
+}
+
+void CvDLLWidgetData::parseCloseScreenHelp(CvWStringBuffer& szBuffer)
+{
+	szBuffer.assign(gDLL->getText("TXT_KEY_MISC_CLOSE_SCREEN"));
+}
+
+void CvDLLWidgetData::parseDescriptionHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer, bool bMinimal)
+{
+	CivilopediaPageTypes eType = (CivilopediaPageTypes)widgetDataStruct.m_iData1;
+	switch (eType)
+	{
+	case CIVILOPEDIA_PAGE_TECH:
+		{
+			TechTypes eTech = (TechTypes)widgetDataStruct.m_iData2;
+			if (NO_TECH != eTech)
+			{
+				szBuffer.assign(bMinimal ? GC.getTechInfo(eTech).getDescription() : gDLL->getText("TXT_KEY_MISC_HISTORICAL_INFO", GC.getTechInfo(eTech).getTextKeyWide()));
+			}
+		}
+		break;
+	case CIVILOPEDIA_PAGE_UNIT:
+		{
+			UnitTypes eUnit = (UnitTypes)widgetDataStruct.m_iData2;
+			if (NO_UNIT != eUnit)
+			{
+				szBuffer.assign(bMinimal ? GC.getUnitInfo(eUnit).getDescription() : gDLL->getText("TXT_KEY_MISC_HISTORICAL_INFO", GC.getUnitInfo(eUnit).getTextKeyWide()));
+			}
+		}
+		break;
+	case CIVILOPEDIA_PAGE_BUILDING:
+	case CIVILOPEDIA_PAGE_WONDER:
+		{
+			BuildingTypes eBuilding = (BuildingTypes)widgetDataStruct.m_iData2;
+			if (NO_BUILDING != eBuilding)
+			{
+				szBuffer.assign(bMinimal ? GC.getBuildingInfo(eBuilding).getDescription() : gDLL->getText("TXT_KEY_MISC_HISTORICAL_INFO", GC.getBuildingInfo(eBuilding).getTextKeyWide()));
+			}
+		}
+		break;
+	case CIVILOPEDIA_PAGE_BONUS:
+		{
+			BonusTypes eBonus = (BonusTypes)widgetDataStruct.m_iData2;
+			if (NO_BONUS != eBonus)
+			{
+				szBuffer.assign(bMinimal ? GC.getBonusInfo(eBonus).getDescription() : gDLL->getText("TXT_KEY_MISC_HISTORICAL_INFO", GC.getBonusInfo(eBonus).getTextKeyWide()));
+			}
+		}
+		break;
+	case CIVILOPEDIA_PAGE_IMPROVEMENT:
+		{
+			ImprovementTypes eImprovement = (ImprovementTypes)widgetDataStruct.m_iData2;
+			if (NO_IMPROVEMENT != eImprovement)
+			{
+				szBuffer.assign(bMinimal ? GC.getImprovementInfo(eImprovement).getDescription() : gDLL->getText("TXT_KEY_MISC_HISTORICAL_INFO", GC.getImprovementInfo(eImprovement).getTextKeyWide()));
+			}
+		}
+		break;
+	case CIVILOPEDIA_PAGE_UNIT_GROUP:
+		{
+			UnitCombatTypes eGroup = (UnitCombatTypes)widgetDataStruct.m_iData2;
+			if (NO_UNITCOMBAT != eGroup)
+			{
+				szBuffer.assign(bMinimal ? GC.getUnitCombatInfo(eGroup).getDescription() : gDLL->getText("TXT_KEY_MISC_HISTORICAL_INFO", GC.getUnitCombatInfo(eGroup).getTextKeyWide()));
+			}
+		}
+		break;
+	case CIVILOPEDIA_PAGE_PROMOTION:
+		{
+			PromotionTypes ePromo = (PromotionTypes)widgetDataStruct.m_iData2;
+			if (NO_PROMOTION != ePromo)
+			{
+				szBuffer.assign(bMinimal ? GC.getPromotionInfo(ePromo).getDescription() : gDLL->getText("TXT_KEY_MISC_HISTORICAL_INFO", GC.getPromotionInfo(ePromo).getTextKeyWide()));
+			}
+		}
+		break;
+	case CIVILOPEDIA_PAGE_CIV:
+		{
+			CivilizationTypes eCiv = (CivilizationTypes)widgetDataStruct.m_iData2;
+			if (NO_CIVILIZATION != eCiv)
+			{
+				szBuffer.assign(bMinimal ? GC.getCivilizationInfo(eCiv).getDescription() : gDLL->getText("TXT_KEY_MISC_HISTORICAL_INFO", GC.getCivilizationInfo(eCiv).getTextKeyWide()));
+			}
+		}
+		break;
+	case CIVILOPEDIA_PAGE_LEADER:
+		{
+			LeaderHeadTypes eLeader = (LeaderHeadTypes)widgetDataStruct.m_iData2;
+			if (NO_LEADER != eLeader)
+			{
+				szBuffer.assign(bMinimal ? GC.getLeaderHeadInfo(eLeader).getDescription() : gDLL->getText("TXT_KEY_MISC_HISTORICAL_INFO", GC.getLeaderHeadInfo(eLeader).getTextKeyWide()));
+			}
+		}
+		break;
+	case CIVILOPEDIA_PAGE_RELIGION:
+		{
+			ReligionTypes eReligion = (ReligionTypes)widgetDataStruct.m_iData2;
+			if (NO_RELIGION != eReligion)
+			{
+				szBuffer.assign(bMinimal ? GC.getReligionInfo(eReligion).getDescription() : gDLL->getText("TXT_KEY_MISC_HISTORICAL_INFO", GC.getReligionInfo(eReligion).getTextKeyWide()));
+			}
+		}
+		break;
+	case CIVILOPEDIA_PAGE_CORPORATION:
+		{
+			CorporationTypes eCorporation = (CorporationTypes)widgetDataStruct.m_iData2;
+			if (NO_CORPORATION != eCorporation)
+			{
+				szBuffer.assign(bMinimal ? GC.getCorporationInfo(eCorporation).getDescription() : gDLL->getText("TXT_KEY_MISC_HISTORICAL_INFO", GC.getCorporationInfo(eCorporation).getTextKeyWide()));
+			}
+		}
+		break;
+	case CIVILOPEDIA_PAGE_CIVIC:
+		{
+			CivicTypes eCivic = (CivicTypes)widgetDataStruct.m_iData2;
+			if (NO_CIVIC != eCivic)
+			{
+				szBuffer.assign(bMinimal ? GC.getCivicInfo(eCivic).getDescription() : gDLL->getText("TXT_KEY_MISC_HISTORICAL_INFO", GC.getCivicInfo(eCivic).getTextKeyWide()));
+			}
+		}
+		break;
+	case CIVILOPEDIA_PAGE_PROJECT:
+		{
+			ProjectTypes eProject = (ProjectTypes)widgetDataStruct.m_iData2;
+			if (NO_PROJECT != eProject)
+			{
+				szBuffer.assign(bMinimal ? GC.getProjectInfo(eProject).getDescription() : gDLL->getText("TXT_KEY_MISC_HISTORICAL_INFO", GC.getProjectInfo(eProject).getTextKeyWide()));
+			}
+		}
+		break;
+	case CIVILOPEDIA_PAGE_CONCEPT:
+		{
+			ConceptTypes eConcept = (ConceptTypes)widgetDataStruct.m_iData2;
+			if (NO_CONCEPT != eConcept)
+			{
+				szBuffer.assign(GC.getConceptInfo(eConcept).getDescription());
+			}
+		}
+		break;
+	case CIVILOPEDIA_PAGE_CONCEPT_NEW:
+		{
+			NewConceptTypes eConcept = (NewConceptTypes)widgetDataStruct.m_iData2;
+			if (NO_CONCEPT != eConcept)
+			{
+				szBuffer.assign(GC.getNewConceptInfo(eConcept).getDescription());
+			}
+		}
+		break;
+	case CIVILOPEDIA_PAGE_SPECIALIST:
+		{
+			SpecialistTypes eSpecialist = (SpecialistTypes)widgetDataStruct.m_iData2;
+			if (NO_SPECIALIST != eSpecialist)
+			{
+				szBuffer.assign(bMinimal ? GC.getSpecialistInfo(eSpecialist).getDescription() : gDLL->getText("TXT_KEY_MISC_HISTORICAL_INFO", GC.getSpecialistInfo(eSpecialist).getTextKeyWide()));
+			}
+		}
+		break;
+	default:
+		break;
+	}
+}
+
+void CvDLLWidgetData::parseKillDealHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+//	szBuffer = "Click to cancel";
+	CvWString szTemp;
+	szTemp = szBuffer.getCString();
+	CvDeal* pDeal = GC.getGameINLINE().getDeal(widgetDataStruct.m_iData1);
+	if (NULL != pDeal)
+	{
+		if (pDeal->isCancelable(GC.getGameINLINE().getActivePlayer(), &szTemp))
+		{
+			szTemp = gDLL->getText("TXT_KEY_MISC_CLICK_TO_CANCEL");
+		}
+	}
+
+	szBuffer.assign(szTemp);
+}
+
+
+void CvDLLWidgetData::doDealKill(CvWidgetDataStruct &widgetDataStruct)
+{
+	CvDeal* pDeal = GC.getGameINLINE().getDeal(widgetDataStruct.m_iData1);
+	if (pDeal != NULL)
+	{
+		if (!pDeal->isCancelable(GC.getGameINLINE().getActivePlayer()))
+		{
+			CvPopupInfo* pInfo = new CvPopupInfo(BUTTONPOPUP_TEXT);
+			if (NULL != pInfo)
+			{
+				pInfo->setText(gDLL->getText("TXT_KEY_POPUP_CANNOT_CANCEL_DEAL"));
+				gDLL->getInterfaceIFace()->addPopup(pInfo, GC.getGameINLINE().getActivePlayer(), true);
+			}
+		}
+		else
+		{
+			CvPopupInfo* pInfo = new CvPopupInfo(BUTTONPOPUP_DEAL_CANCELED);
+			if (NULL != pInfo)
+			{
+				pInfo->setData1(pDeal->getID());
+				pInfo->setOption1(false);
+				gDLL->getInterfaceIFace()->addPopup(pInfo, GC.getGameINLINE().getActivePlayer(), true);
+			}
+		}
+	}
+}
+
+
+void CvDLLWidgetData::doRefreshMilitaryAdvisor(CvWidgetDataStruct &widgetDataStruct)
+{
+	CyArgsList argsList;
+	argsList.add(widgetDataStruct.m_iData1);
+	argsList.add(widgetDataStruct.m_iData2);
+	gDLL->getPythonIFace()->callFunction(PYScreensModule, "refreshMilitaryAdvisor", argsList.makeFunctionArgs());
+}
+
+void CvDLLWidgetData::parseProductionModHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	CvCity* pCity = gDLL->getInterfaceIFace()->getHeadSelectedCity();
+	if (NULL != pCity)
+	{
+		GAMETEXT.setProductionHelp(szBuffer, *pCity);
+	}
+}
+
+void CvDLLWidgetData::parseLeaderheadHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	GAMETEXT.parseLeaderHeadHelp(szBuffer, (PlayerTypes)widgetDataStruct.m_iData1, (PlayerTypes)widgetDataStruct.m_iData2);
+}
+
+void CvDLLWidgetData::parseLeaderLineHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	GAMETEXT.parseLeaderLineHelp(szBuffer, (PlayerTypes)widgetDataStruct.m_iData1, (PlayerTypes)widgetDataStruct.m_iData2);
+}
+
+void CvDLLWidgetData::parseCommerceModHelp(CvWidgetDataStruct &widgetDataStruct, CvWStringBuffer &szBuffer)
+{
+	CvCity* pCity = gDLL->getInterfaceIFace()->getHeadSelectedCity();
+	if (NULL != pCity)
+	{
+		GAMETEXT.setCommerceHelp(szBuffer, *pCity, (CommerceTypes)widgetDataStruct.m_iData1);
+	}
+}
+
+void CvDLLWidgetData::parseScoreHelp(CvWidgetDataStruct& widgetDataStruct, CvWStringBuffer& szBuffer)
+{
+	GAMETEXT.setScoreHelp(szBuffer, (PlayerTypes)widgetDataStruct.m_iData1);
+}
+

--- a/CvPlayer.cpp
+++ b/CvPlayer.cpp
@@ -82,6 +82,9 @@ CvPlayer::CvPlayer()
 
 	m_ppaaiSpecialistExtraYield = NULL;
 	m_ppaaiImprovementYieldChange = NULL;
+	
+	// RBMP Free Tech Popup Fix
+	m_bChoosingFreeTech = false;
 
 	reset(NO_PLAYER, true);
 }
@@ -476,6 +479,9 @@ void CvPlayer::reset(PlayerTypes eID, bool bConstructorCall)
 	m_bExtendedGame = false;
 	m_bFoundedFirstCity = false;
 	m_bStrike = false;
+
+	// RBMP Free Tech Popup Fix
+	m_bChoosingFreeTech = false;
 
 	m_eID = eID;
 	updateTeamType();
@@ -3003,9 +3009,26 @@ bool CvPlayer::hasBusyUnit() const
 	return false;
 }
 
+// RBMP Free Tech Popup Fix
+bool CvPlayer::isChoosingFreeTech() const
+{
+	return m_bChoosingFreeTech;
+}
+
+// RBMP Free Tech Popup Fix
+void CvPlayer::setChoosingFreeTech(bool bValue)
+{
+	m_bChoosingFreeTech = bValue;
+}
 
 void CvPlayer::chooseTech(int iDiscover, CvWString szText, bool bFront)
 {
+	// RBMP Free Tech Popup Fix
+	if (iDiscover > 0)
+	{
+		setChoosingFreeTech(true);
+	}
+
 	CvPopupInfo* pInfo = new CvPopupInfo(BUTTONPOPUP_CHOOSETECH);
 	if (NULL != pInfo)
 	{
@@ -3833,8 +3856,14 @@ bool CvPlayer::canTradeItem(PlayerTypes eWhoTo, TradeData item, bool bTestDenial
 	case TRADE_CITIES:
 		{
 			CvCity* pCityTraded = getCity(item.m_iData);
+			
+			// RBMP bugfix - cancel trade if city to be traded doesn't exist anymore
+			if (NULL == pCityTraded)
+			{
+				return false;
+			}
 
-			if (NULL != pCityTraded && pCityTraded->getLiberationPlayer(false) == eWhoTo)
+			if (pCityTraded->getLiberationPlayer(false) == eWhoTo)
 			{
 				return true;
 			}

--- a/CvPlayer.h
+++ b/CvPlayer.h
@@ -1,0 +1,1287 @@
+#pragma once
+
+// player.h
+
+#ifndef CIV4_PLAYER_H
+#define CIV4_PLAYER_H
+
+#include "CvCityAI.h"
+#include "CvUnitAI.h"
+#include "CvSelectionGroupAI.h"
+#include "CvPlotGroup.h"
+#include "LinkedList.h"
+#include "CvTalkingHeadMessage.h"
+
+class CvDiploParameters;
+class CvPopupInfo;
+class CvEventTriggerInfo;
+
+typedef std::list<CvTalkingHeadMessage> CvMessageQueue;
+typedef std::list<CvPopupInfo*> CvPopupQueue;
+typedef std::list<CvDiploParameters*> CvDiploQueue;
+typedef stdext::hash_map<int, int> CvTurnScoreMap;
+typedef stdext::hash_map<EventTypes, EventTriggeredData> CvEventMap;
+typedef std::vector< std::pair<UnitCombatTypes, PromotionTypes> > UnitCombatPromotionArray;
+typedef std::vector< std::pair<UnitClassTypes, PromotionTypes> > UnitClassPromotionArray;
+typedef std::vector< std::pair<CivilizationTypes, LeaderHeadTypes> > CivLeaderArray;
+
+class CvPlayer
+{
+public:
+	CvPlayer();
+	virtual ~CvPlayer();
+
+	DllExport void init(PlayerTypes eID);
+	DllExport void setupGraphical();
+	DllExport void reset(PlayerTypes eID = NO_PLAYER, bool bConstructorCall = false);
+
+protected:
+
+	void uninit();
+
+public:
+
+	void initFreeState();
+	void initFreeUnits();
+	void addFreeUnitAI(UnitAITypes eUnitAI, int iCount);
+	void addFreeUnit(UnitTypes eUnit, UnitAITypes eUnitAI = NO_UNITAI);
+
+	int startingPlotRange() const;																																									// Exposed to Python
+	bool startingPlotWithinRange(CvPlot* pPlot, PlayerTypes ePlayer, int iRange, int iPass) const;									// Exposed to Python
+	int startingPlotDistanceFactor(CvPlot* pPlot, PlayerTypes ePlayer, int iRange) const;
+	int findStartingArea() const;
+	CvPlot* findStartingPlot(bool bRandomize = false);																																									// Exposed to Python
+
+	CvPlotGroup* initPlotGroup(CvPlot* pPlot);													
+
+	CvCity* initCity(int iX, int iY, bool bBumpUnits, bool bUpdatePlotGroups);																																// Exposed to Python
+	void acquireCity(CvCity* pCity, bool bConquest, bool bTrade, bool bUpdatePlotGroups);																							// Exposed to Python
+	void killCities();																																												// Exposed to Python
+	CvWString getNewCityName() const;																																								// Exposed to Python
+	void getCivilizationCityName(CvWString& szBuffer, CivilizationTypes eCivilization) const;
+	bool isCityNameValid(CvWString& szName, bool bTestDestroyed = true) const;
+
+	CvUnit* initUnit(UnitTypes eUnit, int iX, int iY, UnitAITypes eUnitAI = NO_UNITAI, DirectionTypes eFacingDirection = NO_DIRECTION);							// Exposed to Python
+	void disbandUnit(bool bAnnounce);																																					// Exposed to Python
+	void killUnits();																																													// Exposed to Python
+
+	CvSelectionGroup* cycleSelectionGroups(CvUnit* pUnit, bool bForward, bool bWorkers, bool* pbWrap);
+
+	bool hasTrait(TraitTypes eTrait) const;																																			// Exposed to Python						
+	DllExport bool isHuman() const;																																							// Exposed to Python						
+	DllExport void updateHuman();
+	DllExport bool isBarbarian() const;																																					// Exposed to Python						
+
+	DllExport const wchar* getName(uint uiForm = 0) const;																											// Exposed to Python
+	DllExport const wchar* getNameKey() const;																																	// Exposed to Python
+	DllExport const wchar* getCivilizationDescription(uint uiForm = 0) const;																		// Exposed to Python
+	DllExport const wchar* getCivilizationDescriptionKey() const;																								// Exposed to Python
+	DllExport const wchar* getCivilizationShortDescription(uint uiForm = 0) const;															// Exposed to Python 
+	DllExport const wchar* getCivilizationShortDescriptionKey() const;																					// Exposed to Python 
+	DllExport const wchar* getCivilizationAdjective(uint uiForm = 0) const;																			// Exposed to Python
+	DllExport const wchar* getCivilizationAdjectiveKey() const;																									// Exposed to Python
+	DllExport CvWString getFlagDecal() const;																																		// Exposed to Python
+	DllExport bool isWhiteFlag() const;																																					// Exposed to Python
+	DllExport const wchar* getStateReligionName(uint uiForm = 0) const;																					// Exposed to Python
+	DllExport const wchar* getStateReligionKey() const;																													// Exposed to Python
+	DllExport const CvWString getBestAttackUnitName(uint uiForm = 0) const;																								// Exposed to Python
+	DllExport const CvWString getWorstEnemyName() const;																																	// Exposed to Python
+	const wchar* getBestAttackUnitKey() const;																																	// Exposed to Python
+	DllExport ArtStyleTypes getArtStyleType() const;																														// Exposed to Python
+	DllExport const TCHAR* getUnitButton(UnitTypes eUnit) const;																														// Exposed to Python
+
+	void doTurn();
+	void doTurnUnits();
+
+	void verifyCivics();
+
+	void updatePlotGroups();
+
+	void updateYield();
+	void updateMaintenance();
+	void updatePowerHealth();
+	void updateExtraBuildingHappiness();
+	void updateExtraBuildingHealth();
+	void updateFeatureHappiness();
+	void updateReligionHappiness();
+	void updateExtraSpecialistYield();
+	void updateCommerce(CommerceTypes eCommerce);
+	void updateCommerce();
+	void updateBuildingCommerce();
+	void updateReligionCommerce();
+	void updateCorporation();
+	void updateCityPlotYield();
+	void updateCitySight(bool bIncrement, bool bUpdatePlotGroups);
+	void updateTradeRoutes();
+	void updatePlunder(int iChange, bool bUpdatePlotGroups);
+
+	void updateTimers();
+
+	DllExport bool hasReadyUnit(bool bAny = false) const;
+	DllExport bool hasAutoUnit() const;
+	DllExport bool hasBusyUnit() const;
+
+	// RBMP Free Tech Popup Fix
+	bool isChoosingFreeTech() const;
+	void setChoosingFreeTech(bool bValue);
+
+	DllExport void chooseTech(int iDiscover = 0, CvWString szText = "", bool bFront = false);				// Exposed to Python
+
+	int calculateScore(bool bFinal = false, bool bVictory = false);
+
+	int findBestFoundValue() const;																																				// Exposed to Python
+
+	int upgradeAllPrice(UnitTypes eUpgradeUnit, UnitTypes eFromUnit);
+
+	int countReligionSpreadUnits(CvArea* pArea, ReligionTypes eReligion) const;														// Exposed to Python
+	int countCorporationSpreadUnits(CvArea* pArea, CorporationTypes eCorporation) const;														// Exposed to Python
+	int countNumCoastalCities() const;																																		// Exposed to Python
+	int countNumCoastalCitiesByArea(CvArea* pArea) const;																									// Exposed to Python
+	int countTotalCulture() const;																																				// Exposed to Python
+	int countOwnedBonuses(BonusTypes eBonus) const;																												// Exposed to Python
+	int countUnimprovedBonuses(CvArea* pArea, CvPlot* pFromPlot = NULL) const;														// Exposed to Python
+	int countCityFeatures(FeatureTypes eFeature) const;																										// Exposed to Python
+	int countNumBuildings(BuildingTypes eBuilding) const;																									// Exposed to Python
+	DllExport int countNumCitiesConnectedToCapital() const;																								// Exposed to Python
+	int countPotentialForeignTradeCities(CvArea* pIgnoreArea = NULL) const;																// Exposed to Python
+	int countPotentialForeignTradeCitiesConnected() const;																								// Exposed to Python
+
+	DllExport bool canContact(PlayerTypes ePlayer) const;																									// Exposed to Python
+	void contact(PlayerTypes ePlayer);																															// Exposed to Python
+	DllExport void handleDiploEvent(DiploEventTypes eDiploEvent, PlayerTypes ePlayer, int iData1, int iData2);
+	bool canTradeWith(PlayerTypes eWhoTo) const;																													// Exposed to Python
+	bool canReceiveTradeCity() const;
+	DllExport bool canTradeItem(PlayerTypes eWhoTo, TradeData item, bool bTestDenial = false) const;			// Exposed to Python
+	DllExport DenialTypes getTradeDenial(PlayerTypes eWhoTo, TradeData item) const;												// Exposed to Python
+	bool canTradeNetworkWith(PlayerTypes ePlayer) const;																									// Exposed to Python
+	int getNumAvailableBonuses(BonusTypes eBonus) const;																									// Exposed to Python
+	DllExport int getNumTradeableBonuses(BonusTypes eBonus) const;																				// Exposed to Python
+	int getNumTradeBonusImports(PlayerTypes ePlayer) const;																								// Exposed to Python
+	bool hasBonus(BonusTypes eBonus) const;									// Exposed to Python
+
+	bool isTradingWithTeam(TeamTypes eTeam, bool bIncludeCancelable) const;
+	bool canStopTradingWithTeam(TeamTypes eTeam, bool bContinueNotTrading = false) const;																										// Exposed to Python
+	void stopTradingWithTeam(TeamTypes eTeam);																											// Exposed to Python
+	void killAllDeals();																																						// Exposed to Python
+
+	void findNewCapital();																																					// Exposed to Python 
+	DllExport int getNumGovernmentCenters() const;																												// Exposed to Python 
+
+	DllExport bool canRaze(CvCity* pCity) const;																													// Exposed to Python 
+	void raze(CvCity* pCity);																																				// Exposed to Python  
+	void disband(CvCity* pCity);																																		// Exposed to Python
+
+	bool canReceiveGoody(CvPlot* pPlot, GoodyTypes eGoody, CvUnit* pUnit) const;													// Exposed to Python
+	void receiveGoody(CvPlot* pPlot, GoodyTypes eGoody, CvUnit* pUnit);															// Exposed to Python
+	void doGoody(CvPlot* pPlot, CvUnit* pUnit);																											// Exposed to Python
+
+	DllExport bool canFound(int iX, int iY, bool bTestVisible = false) const;															// Exposed to Python			
+	void found(int iX, int iY);																																			// Exposed to Python			
+
+	DllExport bool canTrain(UnitTypes eUnit, bool bContinue = false, bool bTestVisible = false, bool bIgnoreCost = false) const;										// Exposed to Python
+	bool canConstruct(BuildingTypes eBuilding, bool bContinue = false, bool bTestVisible = false, bool bIgnoreCost = false) const;	// Exposed to Python
+	bool canCreate(ProjectTypes eProject, bool bContinue = false, bool bTestVisible = false) const;							// Exposed to Python
+	bool canMaintain(ProcessTypes eProcess, bool bContinue = false) const;																			// Exposed to Python
+	bool isProductionMaxedUnitClass(UnitClassTypes eUnitClass) const;																						// Exposed to Python
+	bool isProductionMaxedBuildingClass(BuildingClassTypes eBuildingClass, bool bAcquireCity = false) const;		// Exposed to Python
+	bool isProductionMaxedProject(ProjectTypes eProject) const;																									// Exposed to Python
+	DllExport int getProductionNeeded(UnitTypes eUnit) const;																										// Exposed to Python
+	DllExport int getProductionNeeded(BuildingTypes eBuilding) const;																						// Exposed to Python
+	DllExport int getProductionNeeded(ProjectTypes eProject) const;																							// Exposed to Python
+	int getProductionModifier(UnitTypes eUnit) const;
+	int getProductionModifier(BuildingTypes eBuilding) const;
+	int getProductionModifier(ProjectTypes eProject) const;
+
+	DllExport int getBuildingClassPrereqBuilding(BuildingTypes eBuilding, BuildingClassTypes ePrereqBuildingClass, int iExtra = 0) const;	// Exposed to Python
+	void removeBuildingClass(BuildingClassTypes eBuildingClass);																		// Exposed to Python
+	void processBuilding(BuildingTypes eBuilding, int iChange, CvArea* pArea);
+
+	int getBuildCost(const CvPlot* pPlot, BuildTypes eBuild) const;
+	bool canBuild(const CvPlot* pPlot, BuildTypes eBuild, bool bTestEra = false, bool bTestVisible = false) const;	// Exposed to Python
+	RouteTypes getBestRoute(CvPlot* pPlot = NULL) const;																						// Exposed to Python
+	int getImprovementUpgradeRate() const;																													// Exposed to Python
+
+	int calculateTotalYield(YieldTypes eYield) const;																											// Exposed to Python
+	int calculateTotalExports(YieldTypes eYield) const;																										// Exposed to Python
+	int calculateTotalImports(YieldTypes eYield) const;																										// Exposed to Python
+
+	int calculateTotalCityHappiness() const;																															// Exposed to Python
+	int calculateTotalCityUnhappiness() const;																														// Exposed to Python
+
+	int calculateTotalCityHealthiness() const;																														// Exposed to Python
+	int calculateTotalCityUnhealthiness() const;																													// Exposed to Python
+
+	int calculateUnitCost(int& iFreeUnits, int& iFreeMilitaryUnits, int& iPaidUnits, int& iPaidMilitaryUnits, int& iBaseUnitCost, int& iMilitaryCost, int& iExtraCost) const;
+	int calculateUnitCost() const;																																				// Exposed to Python
+	int calculateUnitSupply(int& iPaidUnits, int& iBaseSupplyCost) const;																	// Exposed to Python
+	int calculateUnitSupply() const;																																			// Exposed to Python
+	int calculatePreInflatedCosts() const;																																// Exposed to Python
+	int calculateInflationRate() const;																																		// Exposed to Python
+	int calculateInflatedCosts() const;																																		// Exposed to Python
+
+	int calculateBaseNetGold() const;
+	int calculateBaseNetResearch(TechTypes eTech = NO_TECH) const;   // Exposed to Python
+	int calculateResearchModifier(TechTypes eTech) const;   // Exposed to Python
+	int calculateGoldRate() const;																																				// Exposed to Python
+	int calculateResearchRate(TechTypes eTech = NO_TECH) const;																						// Exposed to Python
+	int calculateTotalCommerce() const;
+
+	bool isResearch() const;																																							// Exposed to Python
+	DllExport bool canEverResearch(TechTypes eTech) const;																								// Exposed to Python
+	DllExport bool canResearch(TechTypes eTech, bool bTrade = false) const;																// Exposed to Python
+	DllExport TechTypes getCurrentResearch() const;																												// Exposed to Python
+	bool isCurrentResearchRepeat() const;																																	// Exposed to Python
+	bool isNoResearchAvailable() const;																																		// Exposed to Python
+	DllExport int getResearchTurnsLeft(TechTypes eTech, bool bOverflow) const;														// Exposed to Python
+
+	bool isCivic(CivicTypes eCivic) const;																																// Exposed to Python
+	bool canDoCivics(CivicTypes eCivic) const;																														// Exposed to Python
+	DllExport bool canRevolution(CivicTypes* paeNewCivics) const;																					// Exposed to Python
+	DllExport void revolution(CivicTypes* paeNewCivics, bool bForce = false);												// Exposed to Python
+	int getCivicPercentAnger(CivicTypes eCivic, bool bIgnore = false) const;																										// Exposed to Python
+
+	bool canDoReligion(ReligionTypes eReligion) const;																										// Exposed to Python
+	bool canChangeReligion() const;																																				// Exposed to Python
+	DllExport bool canConvert(ReligionTypes eReligion) const;																							// Exposed to Python
+	DllExport void convert(ReligionTypes eReligion);																								// Exposed to Python
+	bool hasHolyCity(ReligionTypes eReligion) const;																											// Exposed to Python
+	int countHolyCities() const;																																					// Exposed to Python
+	DllExport void foundReligion(ReligionTypes eReligion, ReligionTypes eSlotReligion, bool bAward);																										// Exposed to Python
+
+	bool hasHeadquarters(CorporationTypes eCorporation) const;																											// Exposed to Python
+	int countHeadquarters() const;																																					// Exposed to Python
+	int countCorporations(CorporationTypes eCorporation) const;																																					// Exposed to Python
+	void foundCorporation(CorporationTypes eCorporation);																										// Exposed to Python
+
+	DllExport int getCivicAnarchyLength(CivicTypes* paeNewCivics) const;																	// Exposed to Python
+	DllExport int getReligionAnarchyLength() const;																												// Exposed to Python
+
+	DllExport int unitsRequiredForGoldenAge() const;																											// Exposed to Python
+	int unitsGoldenAgeCapable() const;																																		// Exposed to Python
+	DllExport int unitsGoldenAgeReady() const;																														// Exposed to Python
+	void killGoldenAgeUnits(CvUnit* pUnitAlive);
+
+	DllExport int greatPeopleThreshold(bool bMilitary = false) const;																														// Exposed to Python
+	int specialistYield(SpecialistTypes eSpecialist, YieldTypes eYield) const;														// Exposed to Python
+	int specialistCommerce(SpecialistTypes eSpecialist, CommerceTypes eCommerce) const;										// Exposed to Python
+
+	DllExport CvPlot* getStartingPlot() const;																																			// Exposed to Python
+	DllExport void setStartingPlot(CvPlot* pNewValue, bool bUpdateStartDist);												// Exposed to Python
+
+	DllExport int getTotalPopulation() const;																															// Exposed to Python
+	int getAveragePopulation() const;																																			// Exposed to Python
+	void changeTotalPopulation(int iChange);
+	long getRealPopulation() const;																																				// Exposed to Python
+	int getReligionPopulation(ReligionTypes eReligion) const;
+
+	int getTotalLand() const;																																							// Exposed to Python
+	void changeTotalLand(int iChange);
+
+	int getTotalLandScored() const;																																				// Exposed to Python
+	void changeTotalLandScored(int iChange);
+
+	DllExport int getGold() const;																																				// Exposed to Python
+	DllExport void setGold(int iNewValue);																													// Exposed to Python
+	DllExport void changeGold(int iChange);																													// Exposed to Python
+
+	int getGoldPerTurn() const;																																						// Exposed to Python
+
+	DllExport int getAdvancedStartPoints() const;																																				// Exposed to Python
+	DllExport void setAdvancedStartPoints(int iNewValue);																													// Exposed to Python
+	DllExport void changeAdvancedStartPoints(int iChange);																													// Exposed to Python
+
+	int getEspionageSpending(TeamTypes eAgainstTeam) const;																								// Exposed to Python
+	DllExport bool canDoEspionageMission(EspionageMissionTypes eMission, PlayerTypes eTargetPlayer, const CvPlot* pPlot, int iExtraData, const CvUnit* pUnit) const;		// Exposed to Python
+	int getEspionageMissionBaseCost(EspionageMissionTypes eMission, PlayerTypes eTargetPlayer, const CvPlot* pPlot, int iExtraData, const CvUnit* pSpyUnit) const;
+	int getEspionageMissionCost(EspionageMissionTypes eMission, PlayerTypes eTargetPlayer, const CvPlot* pPlot = NULL, int iExtraData = -1, const CvUnit* pSpyUnit = NULL) const;		// Exposed to Python
+	int getEspionageMissionCostModifier(EspionageMissionTypes eMission, PlayerTypes eTargetPlayer, const CvPlot* pPlot = NULL, int iExtraData = -1, const CvUnit* pSpyUnit = NULL) const;
+	bool doEspionageMission(EspionageMissionTypes eMission, PlayerTypes eTargetPlayer, CvPlot* pPlot, int iExtraData, CvUnit* pUnit);
+
+	int getEspionageSpendingWeightAgainstTeam(TeamTypes eIndex) const;																							// Exposed to Python
+	void setEspionageSpendingWeightAgainstTeam(TeamTypes eIndex, int iValue);																		// Exposed to Python
+	DllExport void changeEspionageSpendingWeightAgainstTeam(TeamTypes eIndex, int iChange);																// Exposed to Python
+
+	bool canStealTech(PlayerTypes eTarget, TechTypes eTech) const;
+	bool canForceCivics(PlayerTypes eTarget, CivicTypes eCivic) const;
+	bool canForceReligion(PlayerTypes eTarget, ReligionTypes eReligion) const;
+	bool canSpyDestroyUnit(PlayerTypes eTarget, CvUnit& kUnit) const;
+	bool canSpyBribeUnit(PlayerTypes eTarget, CvUnit& kUnit) const;
+	bool canSpyDestroyBuilding(PlayerTypes eTarget, BuildingTypes eBuilding) const;
+	bool canSpyDestroyProject(PlayerTypes eTarget, ProjectTypes eProject) const;
+
+	DllExport void doAdvancedStartAction(AdvancedStartActionTypes eAction, int iX, int iY, int iData, bool bAdd);
+	DllExport int getAdvancedStartUnitCost(UnitTypes eUnit, bool bAdd, CvPlot* pPlot = NULL) const;																													// Exposed to Python 
+	DllExport int getAdvancedStartCityCost(bool bAdd, CvPlot* pPlot = NULL) const;																													// Exposed to Python 
+	DllExport int getAdvancedStartPopCost(bool bAdd, CvCity* pCity = NULL) const;																													// Exposed to Python 
+	DllExport int getAdvancedStartCultureCost(bool bAdd, CvCity* pCity = NULL) const;																													// Exposed to Python 
+	DllExport int getAdvancedStartBuildingCost(BuildingTypes eBuilding, bool bAdd, CvCity* pCity = NULL) const;																													// Exposed to Python 
+	DllExport int getAdvancedStartImprovementCost(ImprovementTypes eImprovement, bool bAdd, CvPlot* pPlot = NULL) const;																													// Exposed to Python 
+	DllExport int getAdvancedStartRouteCost(RouteTypes eRoute, bool bAdd, CvPlot* pPlot = NULL) const;																													// Exposed to Python 
+	DllExport int getAdvancedStartTechCost(TechTypes eTech, bool bAdd) const;																													// Exposed to Python 
+	DllExport int getAdvancedStartVisibilityCost(bool bAdd, CvPlot* pPlot = NULL) const;																													// Exposed to Python 
+
+	DllExport int getGoldenAgeTurns() const;																															// Exposed to Python  
+	DllExport bool isGoldenAge() const;																																		// Exposed to Python 
+	void changeGoldenAgeTurns(int iChange);																													// Exposed to Python 
+	int getGoldenAgeLength() const;
+
+	int getNumUnitGoldenAges() const;																																			// Exposed to Python 
+	void changeNumUnitGoldenAges(int iChange);																											// Exposed to Python 
+
+	int getAnarchyTurns() const;																																					// Exposed to Python
+	DllExport bool isAnarchy() const;																																			// Exposed to Python
+	void changeAnarchyTurns(int iChange);																														// Exposed to Python
+
+	int getStrikeTurns() const;																																						// Exposed to Python
+	void changeStrikeTurns(int iChange);
+
+	int getMaxAnarchyTurns() const;																																				// Exposed to Python 
+	void updateMaxAnarchyTurns();
+
+	int getAnarchyModifier() const;																																				// Exposed to Python 
+	void changeAnarchyModifier(int iChange);
+
+	int getGoldenAgeModifier() const;																																				// Exposed to Python 
+	void changeGoldenAgeModifier(int iChange);
+
+	int getHurryModifier() const;																																					// Exposed to Python
+	void changeHurryModifier(int iChange);
+
+	void createGreatPeople(UnitTypes eGreatPersonUnit, bool bIncrementThreshold, bool bIncrementExperience, int iX, int iY);
+
+	int getGreatPeopleCreated() const;																																		// Exposed to Python
+	void incrementGreatPeopleCreated();
+
+	int getGreatGeneralsCreated() const;																																		// Exposed to Python
+	void incrementGreatGeneralsCreated();
+
+	int getGreatPeopleThresholdModifier() const;																													// Exposed to Python
+	void changeGreatPeopleThresholdModifier(int iChange);										
+
+	int getGreatGeneralsThresholdModifier() const;																													// Exposed to Python
+	void changeGreatGeneralsThresholdModifier(int iChange);										
+
+	int getGreatPeopleRateModifier() const;																																// Exposed to Python
+	void changeGreatPeopleRateModifier(int iChange);
+
+	int getGreatGeneralRateModifier() const;																																// Exposed to Python
+	void changeGreatGeneralRateModifier(int iChange);
+
+	int getDomesticGreatGeneralRateModifier() const;																																// Exposed to Python
+	void changeDomesticGreatGeneralRateModifier(int iChange);
+
+	int getStateReligionGreatPeopleRateModifier() const;																									// Exposed to Python
+	void changeStateReligionGreatPeopleRateModifier(int iChange);
+
+	int getMaxGlobalBuildingProductionModifier() const;																										// Exposed to Python
+	void changeMaxGlobalBuildingProductionModifier(int iChange);
+
+	int getMaxTeamBuildingProductionModifier() const;																											// Exposed to Python 
+	void changeMaxTeamBuildingProductionModifier(int iChange);
+
+	int getMaxPlayerBuildingProductionModifier() const;																										// Exposed to Python
+	void changeMaxPlayerBuildingProductionModifier(int iChange);
+
+	int getFreeExperience() const;																																				// Exposed to Python
+	void changeFreeExperience(int iChange);
+
+	int getFeatureProductionModifier() const;																															// Exposed to Python
+	void changeFeatureProductionModifier(int iChange);
+
+	int getWorkerSpeedModifier() const;																																		// Exposed to Python
+	void changeWorkerSpeedModifier(int iChange);
+
+	int getImprovementUpgradeRateModifier() const;																									// Exposed to Python
+	void changeImprovementUpgradeRateModifier(int iChange);
+
+	int getMilitaryProductionModifier() const;																											// Exposed to Python
+	void changeMilitaryProductionModifier(int iChange);
+
+	int getSpaceProductionModifier() const;																																// Exposed to Python  
+	void changeSpaceProductionModifier(int iChange);
+
+	int getCityDefenseModifier() const;																																		// Exposed to Python
+	void changeCityDefenseModifier(int iChange);
+
+	int getNumNukeUnits() const;																																					// Exposed to Python
+	void changeNumNukeUnits(int iChange);
+
+	int getNumOutsideUnits() const;																																				// Exposed to Python
+	void changeNumOutsideUnits(int iChange);
+
+	int getBaseFreeUnits() const;																																					// Exposed to Python
+	void changeBaseFreeUnits(int iChange);
+
+	int getBaseFreeMilitaryUnits() const;																																	// Exposed to Python
+	void changeBaseFreeMilitaryUnits(int iChange);
+
+	int getFreeUnitsPopulationPercent() const;																														// Exposed to Python
+	void changeFreeUnitsPopulationPercent(int iChange);
+
+	int getFreeMilitaryUnitsPopulationPercent() const;																										// Exposed to Python
+	void changeFreeMilitaryUnitsPopulationPercent(int iChange);											
+
+	int getGoldPerUnit() const;																																								// Exposed to Python
+	void changeGoldPerUnit(int iChange);															
+
+	int getGoldPerMilitaryUnit() const;																																				// Exposed to Python
+	void changeGoldPerMilitaryUnit(int iChange);
+
+	int getExtraUnitCost() const;																																							// Exposed to Python 
+	void changeExtraUnitCost(int iChange);
+
+	int getNumMilitaryUnits() const;																																					// Exposed to Python
+	void changeNumMilitaryUnits(int iChange);													
+
+	int getHappyPerMilitaryUnit() const;																																			// Exposed to Python
+	void changeHappyPerMilitaryUnit(int iChange);												
+
+	int getMilitaryFoodProductionCount() const;														
+	bool isMilitaryFoodProduction() const;																																		// Exposed to Python
+	void changeMilitaryFoodProductionCount(int iChange);
+
+	int getHighestUnitLevel() const;																																					// Exposed to Python
+	void setHighestUnitLevel(int iNewValue);
+
+	int getConscriptCount() const;																																						// Exposed to Python
+	void setConscriptCount(int iNewValue);																															// Exposed to Python
+	void changeConscriptCount(int iChange);																															// Exposed to Python
+
+	DllExport int getMaxConscript() const;																																		// Exposed to Python
+	void changeMaxConscript(int iChange);														
+
+	DllExport int getOverflowResearch() const;																																// Exposed to Python
+	void setOverflowResearch(int iNewValue);																														// Exposed to Python
+	void changeOverflowResearch(int iChange);																														// Exposed to Python
+
+	int getNoUnhealthyPopulationCount() const;
+	bool isNoUnhealthyPopulation() const;																																			// Exposed to Python
+	void changeNoUnhealthyPopulationCount(int iChange);
+
+	int getExpInBorderModifier() const;
+	void changeExpInBorderModifier(int iChange);
+
+	int getBuildingOnlyHealthyCount() const;
+	bool isBuildingOnlyHealthy() const;																																				// Exposed to Python
+	void changeBuildingOnlyHealthyCount(int iChange);
+
+	int getDistanceMaintenanceModifier() const;																																// Exposed to Python
+	void changeDistanceMaintenanceModifier(int iChange);
+
+	int getNumCitiesMaintenanceModifier() const;																															// Exposed to Python
+	void changeNumCitiesMaintenanceModifier(int iChange);
+
+	int getCorporationMaintenanceModifier() const;																															// Exposed to Python
+	void changeCorporationMaintenanceModifier(int iChange);
+
+	int getTotalMaintenance() const;																																					// Exposed to Python
+	void changeTotalMaintenance(int iChange);
+
+	int getUpkeepModifier() const;																																						// Exposed to Python
+	void changeUpkeepModifier(int iChange);
+
+	int getLevelExperienceModifier() const;																																						// Exposed to Python
+	void changeLevelExperienceModifier(int iChange);
+
+	DllExport int getExtraHealth() const;																																			// Exposed to Python
+	void changeExtraHealth(int iChange);
+
+	int getBuildingGoodHealth() const;																																				// Exposed to Python
+	void changeBuildingGoodHealth(int iChange);
+
+	int getBuildingBadHealth() const;																																					// Exposed to Python
+	void changeBuildingBadHealth(int iChange);
+
+	int getExtraHappiness() const;																																						// Exposed to Python
+	void changeExtraHappiness(int iChange);
+
+	int getBuildingHappiness() const;																																					// Exposed to Python
+	void changeBuildingHappiness(int iChange);
+
+	int getLargestCityHappiness() const;																																			// Exposed to Python
+	void changeLargestCityHappiness(int iChange);
+
+	int getWarWearinessPercentAnger() const;																																	// Exposed to Python 
+	void updateWarWearinessPercentAnger();
+	int getModifiedWarWearinessPercentAnger(int iWarWearinessPercentAnger) const;
+
+	int getWarWearinessModifier() const;																																			// Exposed to Python
+	void changeWarWearinessModifier(int iChange);
+
+	int getFreeSpecialist() const;																																						// Exposed to Python
+	void changeFreeSpecialist(int iChange);
+
+	int getNoForeignTradeCount() const;
+	bool isNoForeignTrade() const;																																						// Exposed to Python
+	void changeNoForeignTradeCount(int iChange);
+
+	int getNoCorporationsCount() const;
+	bool isNoCorporations() const;																																						// Exposed to Python
+	void changeNoCorporationsCount(int iChange);
+
+	int getNoForeignCorporationsCount() const;
+	bool isNoForeignCorporations() const;																																						// Exposed to Python
+	void changeNoForeignCorporationsCount(int iChange);
+
+	int getCoastalTradeRoutes() const;																																				// Exposed to Python
+	void changeCoastalTradeRoutes(int iChange);																													// Exposed to Python
+
+	int getTradeRoutes() const;																																								// Exposed to Python
+	void changeTradeRoutes(int iChange);																																// Exposed to Python
+
+	DllExport int getRevolutionTimer() const;																																	// Exposed to Python
+	void setRevolutionTimer(int iNewValue);
+	void changeRevolutionTimer(int iChange);
+
+	int getConversionTimer() const;																																						// Exposed to Python
+	void setConversionTimer(int iNewValue);
+	void changeConversionTimer(int iChange);
+
+	int getStateReligionCount() const;
+	bool isStateReligion() const;																																							// Exposed to Python
+	void changeStateReligionCount(int iChange);
+
+	int getNoNonStateReligionSpreadCount() const;
+	DllExport bool isNoNonStateReligionSpread() const;																												// Exposed to Python
+	void changeNoNonStateReligionSpreadCount(int iChange);
+
+	DllExport int getStateReligionHappiness() const;																													// Exposed to Python
+	void changeStateReligionHappiness(int iChange);
+
+	int getNonStateReligionHappiness() const;																																	// Exposed to Python
+	void changeNonStateReligionHappiness(int iChange);
+
+	int getStateReligionUnitProductionModifier() const;																												// Exposed to Python 
+	void changeStateReligionUnitProductionModifier(int iChange);
+
+	int getStateReligionBuildingProductionModifier() const;																										// Exposed to Python
+	void changeStateReligionBuildingProductionModifier(int iChange);																		// Exposed to Python
+
+	int getStateReligionFreeExperience() const;																																// Exposed to Python
+	void changeStateReligionFreeExperience(int iChange);
+
+	DllExport CvCity* getCapitalCity() const;																																	// Exposed to Python
+	void setCapitalCity(CvCity* pNewCapitalCity);
+
+	int getCitiesLost() const;																																								// Exposed to Python
+	void changeCitiesLost(int iChange);
+
+	int getWinsVsBarbs() const;																																								// Exposed to Python
+	void changeWinsVsBarbs(int iChange);
+
+	DllExport int getAssets() const;																																					// Exposed to Python
+	void changeAssets(int iChange);																																			// Exposed to Python  
+
+	DllExport int getPower() const;																																						// Exposed to Python
+	void changePower(int iChange);
+
+	DllExport int getPopScore(bool bCheckVassal = true) const;																																				// Exposed to Python
+	void changePopScore(int iChange);																																		// Exposed to Python  
+	DllExport int getLandScore(bool bCheckVassal = true) const;																																				// Exposed to Python
+	void changeLandScore(int iChange);																																	// Exposed to Python  
+	DllExport int getTechScore() const;																																				// Exposed to Python
+	void changeTechScore(int iChange);																																	// Exposed to Python  
+	DllExport int getWondersScore() const;																																		// Exposed to Python
+	void changeWondersScore(int iChange);	// Exposed to Python  
+
+	int getCombatExperience() const; 	// Exposed to Python  
+	void setCombatExperience(int iExperience);   // Exposed to Python
+	void changeCombatExperience(int iChange);   // Exposed to Python
+
+	DllExport bool isConnected() const;
+	DllExport int getNetID() const;
+	DllExport void setNetID(int iNetID);
+	DllExport void sendReminder();
+
+	uint getStartTime() const;
+	DllExport void setStartTime(uint uiStartTime);
+	DllExport uint getTotalTimePlayed() const;																																// Exposed to Python			  
+																																																			
+	bool isMinorCiv() const;																																									// Exposed to Python			
+																																																			
+	DllExport bool isAlive() const;																																						// Exposed to Python			
+	DllExport bool isEverAlive() const;																																				// Exposed to Python			
+	void setAlive(bool bNewValue);
+	void verifyAlive();
+
+	DllExport bool isTurnActive() const;																			
+	DllExport void setTurnActive(bool bNewValue, bool bDoTurn = true);
+
+	bool isAutoMoves() const;
+	DllExport void setAutoMoves(bool bNewValue);
+	DllExport void setTurnActiveForPbem(bool bActive);
+
+	DllExport bool isPbemNewTurn() const;
+	DllExport void setPbemNewTurn(bool bNew);
+
+	bool isEndTurn() const;
+	DllExport void setEndTurn(bool bNewValue);
+
+	DllExport bool isTurnDone() const;
+
+	bool isExtendedGame() const;																																			// Exposed to Python					
+	DllExport void makeExtendedGame();																													
+																																															
+	bool isFoundedFirstCity() const;																																	// Exposed to Python					
+	void setFoundedFirstCity(bool bNewValue);																										
+																																															
+	DllExport bool isStrike() const;																																	// Exposed to Python					
+	void setStrike(bool bNewValue);																															
+
+	DllExport PlayerTypes getID() const;																												// Exposed to Python					
+																																															
+	DllExport HandicapTypes getHandicapType() const;																									// Exposed to Python					
+																																															
+	DllExport CivilizationTypes getCivilizationType() const;																					// Exposed to Python					
+																																															
+	DllExport LeaderHeadTypes getLeaderType() const;																									// Exposed to Python					
+																																															
+	LeaderHeadTypes getPersonalityType() const;																												// Exposed to Python									
+	void setPersonalityType(LeaderHeadTypes eNewValue);																					// Exposed to Python									
+																																																				
+	DllExport EraTypes getCurrentEra() const;																										// Exposed to Python									
+	void setCurrentEra(EraTypes eNewValue);																											
+																																															
+	ReligionTypes getLastStateReligion() const;																												
+	DllExport ReligionTypes getStateReligion() const;																									// Exposed to Python					
+	void setLastStateReligion(ReligionTypes eNewValue);																					// Exposed to Python					
+																																															
+	PlayerTypes getParent() const;
+	void setParent(PlayerTypes eParent);
+
+	DllExport TeamTypes getTeam() const;																												// Exposed to Python					
+	void setTeam(TeamTypes eTeam);		
+	void updateTeamType();
+																																																							
+	DllExport PlayerColorTypes getPlayerColor() const;																								// Exposed to Python									
+	DllExport int getPlayerTextColorR() const;																												// Exposed to Python								
+	DllExport int getPlayerTextColorG() const;																												// Exposed to Python									
+	DllExport int getPlayerTextColorB() const;																												// Exposed to Python									
+	DllExport int getPlayerTextColorA() const;																												// Exposed to Python									
+																																									
+	int getSeaPlotYield(YieldTypes eIndex) const;																											// Exposed to Python
+	void changeSeaPlotYield(YieldTypes eIndex, int iChange);
+
+	int getYieldRateModifier(YieldTypes eIndex) const;																								// Exposed to Python
+	void changeYieldRateModifier(YieldTypes eIndex, int iChange);
+
+	int getCapitalYieldRateModifier(YieldTypes eIndex) const;																					// Exposed to Python
+	void changeCapitalYieldRateModifier(YieldTypes eIndex, int iChange);
+
+	int getExtraYieldThreshold(YieldTypes eIndex) const;																							// Exposed to Python
+	void updateExtraYieldThreshold(YieldTypes eIndex);
+
+	int getTradeYieldModifier(YieldTypes eIndex) const;																								// Exposed to Python
+	void changeTradeYieldModifier(YieldTypes eIndex, int iChange);
+
+	int getFreeCityCommerce(CommerceTypes eIndex) const;																							// Exposed to Python
+	void changeFreeCityCommerce(CommerceTypes eIndex, int iChange);
+
+	int getCommercePercent(CommerceTypes eIndex) const;																								// Exposed to Python
+	void setCommercePercent(CommerceTypes eIndex, int iNewValue);																// Exposed to Python
+	DllExport void changeCommercePercent(CommerceTypes eIndex, int iChange);										// Exposed to Python
+
+	int getCommerceRate(CommerceTypes eIndex) const;																									// Exposed to Python
+	void changeCommerceRate(CommerceTypes eIndex, int iChange);
+
+	int getCommerceRateModifier(CommerceTypes eIndex) const;																					// Exposed to Python
+	void changeCommerceRateModifier(CommerceTypes eIndex, int iChange);
+
+	int getCapitalCommerceRateModifier(CommerceTypes eIndex) const;																		// Exposed to Python
+	void changeCapitalCommerceRateModifier(CommerceTypes eIndex, int iChange);
+
+	int getStateReligionBuildingCommerce(CommerceTypes eIndex) const;																	// Exposed to Python
+	void changeStateReligionBuildingCommerce(CommerceTypes eIndex, int iChange);
+
+	int getSpecialistExtraCommerce(CommerceTypes eIndex) const;																				// Exposed to Python
+	void changeSpecialistExtraCommerce(CommerceTypes eIndex, int iChange);
+
+	int getCommerceFlexibleCount(CommerceTypes eIndex) const;
+	bool isCommerceFlexible(CommerceTypes eIndex) const;																							// Exposed to Python
+	void changeCommerceFlexibleCount(CommerceTypes eIndex, int iChange);
+
+	int getGoldPerTurnByPlayer(PlayerTypes eIndex) const;																							// Exposed to Python
+	void changeGoldPerTurnByPlayer(PlayerTypes eIndex, int iChange);
+
+	bool isFeatAccomplished(FeatTypes eIndex) const;																									// Exposed to Python
+	void setFeatAccomplished(FeatTypes eIndex, bool bNewValue);																	// Exposed to Python
+
+	DllExport bool isOption(PlayerOptionTypes eIndex) const;																		// Exposed to Python
+	DllExport void setOption(PlayerOptionTypes eIndex, bool bNewValue);													// Exposed to Python
+
+	DllExport bool isLoyalMember(VoteSourceTypes eVoteSource) const;																		// Exposed to Python
+	DllExport void setLoyalMember(VoteSourceTypes eVoteSource, bool bNewValue);													// Exposed to Python
+
+	DllExport bool isPlayable() const;
+	DllExport void setPlayable(bool bNewValue);
+
+	int getBonusExport(BonusTypes eIndex) const;																											// Exposed to Python
+	void changeBonusExport(BonusTypes eIndex, int iChange);
+
+	int getBonusImport(BonusTypes eIndex) const;																											// Exposed to Python
+	void changeBonusImport(BonusTypes eIndex, int iChange);
+
+	int getImprovementCount(ImprovementTypes eIndex) const;																						// Exposed to Python
+	void changeImprovementCount(ImprovementTypes eIndex, int iChange);
+
+	int getFreeBuildingCount(BuildingTypes eIndex) const;
+	bool isBuildingFree(BuildingTypes eIndex) const;																									// Exposed to Python
+	void changeFreeBuildingCount(BuildingTypes eIndex, int iChange);
+
+	int getExtraBuildingHappiness(BuildingTypes eIndex) const;																				// Exposed to Python
+	void changeExtraBuildingHappiness(BuildingTypes eIndex, int iChange);
+	int getExtraBuildingHealth(BuildingTypes eIndex) const;																				// Exposed to Python
+	void changeExtraBuildingHealth(BuildingTypes eIndex, int iChange);
+
+	int getFeatureHappiness(FeatureTypes eIndex) const;																								// Exposed to Python
+	void changeFeatureHappiness(FeatureTypes eIndex, int iChange);
+
+	int getUnitClassCount(UnitClassTypes eIndex) const;																								// Exposed to Python
+	bool isUnitClassMaxedOut(UnitClassTypes eIndex, int iExtra = 0) const;														// Exposed to Python
+	void changeUnitClassCount(UnitClassTypes eIndex, int iChange);
+	int getUnitClassMaking(UnitClassTypes eIndex) const;																							// Exposed to Python
+	void changeUnitClassMaking(UnitClassTypes eIndex, int iChange);
+	int getUnitClassCountPlusMaking(UnitClassTypes eIndex) const;																			// Exposed to Python
+
+	int getBuildingClassCount(BuildingClassTypes eIndex) const;																				// Exposed to Python
+	bool isBuildingClassMaxedOut(BuildingClassTypes eIndex, int iExtra = 0) const;										// Exposed to Python
+	void changeBuildingClassCount(BuildingClassTypes eIndex, int iChange);
+	int getBuildingClassMaking(BuildingClassTypes eIndex) const;																			// Exposed to Python 
+	void changeBuildingClassMaking(BuildingClassTypes eIndex, int iChange);
+	int getBuildingClassCountPlusMaking(BuildingClassTypes eIndex) const;															// Exposed to Python
+
+	int getHurryCount(HurryTypes eIndex) const;																												// Exposed to Python
+	DllExport bool canHurry(HurryTypes eIndex) const;																									// Exposed to Python
+	bool canPopRush();
+	void changeHurryCount(HurryTypes eIndex, int iChange);
+
+	int getSpecialBuildingNotRequiredCount(SpecialBuildingTypes eIndex) const;												// Exposed to Python
+	bool isSpecialBuildingNotRequired(SpecialBuildingTypes eIndex) const;															// Exposed to Python
+	void changeSpecialBuildingNotRequiredCount(SpecialBuildingTypes eIndex, int iChange);
+
+	int getHasCivicOptionCount(CivicOptionTypes eIndex) const;
+	bool isHasCivicOption(CivicOptionTypes eIndex) const;																							// Exposed to Python
+	void changeHasCivicOptionCount(CivicOptionTypes eIndex, int iChange);
+
+	int getNoCivicUpkeepCount(CivicOptionTypes eIndex) const;
+	bool isNoCivicUpkeep(CivicOptionTypes eIndex) const;																							// Exposed to Python
+	void changeNoCivicUpkeepCount(CivicOptionTypes eIndex, int iChange);
+
+	int getHasReligionCount(ReligionTypes eIndex) const;																							// Exposed to Python
+	int countTotalHasReligion() const;																																// Exposed to Python
+	int findHighestHasReligionCount() const;																													// Exposed to Python
+	void changeHasReligionCount(ReligionTypes eIndex, int iChange);
+
+	int getHasCorporationCount(CorporationTypes eIndex) const;																							// Exposed to Python
+	int countTotalHasCorporation() const;																																// Exposed to Python
+	void changeHasCorporationCount(CorporationTypes eIndex, int iChange);
+	bool isActiveCorporation(CorporationTypes eIndex) const;
+
+	int getUpkeepCount(UpkeepTypes eIndex) const;																											// Exposed to Python
+	void changeUpkeepCount(UpkeepTypes eIndex, int iChange);
+
+	int getSpecialistValidCount(SpecialistTypes eIndex) const;
+	DllExport bool isSpecialistValid(SpecialistTypes eIndex) const;																		// Exposed to Python					
+	void changeSpecialistValidCount(SpecialistTypes eIndex, int iChange);												
+																																															
+	DllExport bool isResearchingTech(TechTypes eIndex) const;																					// Exposed to Python					
+	void setResearchingTech(TechTypes eIndex, bool bNewValue);																	
+																																															
+	DllExport CivicTypes getCivics(CivicOptionTypes eIndex) const;																		// Exposed to Python					
+	int getSingleCivicUpkeep(CivicTypes eCivic, bool bIgnoreAnarchy = false) const;										// Exposed to Python					
+	int getCivicUpkeep(CivicTypes* paeCivics = NULL, bool bIgnoreAnarchy = false) const;							// Exposed to Python					
+	void setCivics(CivicOptionTypes eIndex, CivicTypes eNewValue);															// Exposed to Python					
+
+	int getSpecialistExtraYield(SpecialistTypes eIndex1, YieldTypes eIndex2) const;										// Exposed to Python
+	void changeSpecialistExtraYield(SpecialistTypes eIndex1, YieldTypes eIndex2, int iChange);
+
+	int getImprovementYieldChange(ImprovementTypes eIndex1, YieldTypes eIndex2) const;								// Exposed to Python
+	void changeImprovementYieldChange(ImprovementTypes eIndex1, YieldTypes eIndex2, int iChange);
+
+	void updateGroupCycle(CvUnit* pUnit);
+	void removeGroupCycle(int iID);
+	CLLNode<int>* deleteGroupCycleNode(CLLNode<int>* pNode);
+	CLLNode<int>* nextGroupCycleNode(CLLNode<int>* pNode) const;
+	CLLNode<int>* previousGroupCycleNode(CLLNode<int>* pNode) const;
+	CLLNode<int>* headGroupCycleNode() const;
+	CLLNode<int>* tailGroupCycleNode() const;
+
+	int findPathLength(TechTypes eTech, bool bCost = true) const;																			// Exposed to Python
+	int getQueuePosition(TechTypes eTech) const;																											// Exposed to Python
+	DllExport void clearResearchQueue();																												// Exposed to Python
+	DllExport bool pushResearch(TechTypes eTech, bool bClear = false);													// Exposed to Python
+	void popResearch(TechTypes eTech);																													// Exposed to Python
+	int getLengthResearchQueue() const;																																// Exposed to Python
+	CLLNode<TechTypes>* nextResearchQueueNode(CLLNode<TechTypes>* pNode) const;
+	CLLNode<TechTypes>* headResearchQueueNode() const;
+	CLLNode<TechTypes>* tailResearchQueueNode() const;
+
+	void addCityName(const CvWString& szName);																									// Exposed to Python
+	int getNumCityNames() const;																																// Exposed to Python
+	CvWString getCityName(int iIndex) const;																										// Exposed to Python
+	CLLNode<CvWString>* nextCityNameNode(CLLNode<CvWString>* pNode) const;
+	CLLNode<CvWString>* headCityNameNode() const;
+
+	// plot groups iteration
+	CvPlotGroup* firstPlotGroup(int *pIterIdx, bool bRev=false) const;
+	CvPlotGroup* nextPlotGroup(int *pIterIdx, bool bRev=false) const;
+	int getNumPlotGroups() const;
+	CvPlotGroup* getPlotGroup(int iID) const;
+	CvPlotGroup* addPlotGroup();
+	void deletePlotGroup(int iID);
+
+	// city iteration
+	DllExport CvCity* firstCity(int *pIterIdx, bool bRev=false) const;																// Exposed to Python					
+	DllExport CvCity* nextCity(int *pIterIdx, bool bRev=false) const;																	// Exposed to Python					
+	DllExport int getNumCities() const;																																// Exposed to Python					
+	DllExport CvCity* getCity(int iID) const;																													// Exposed to Python					
+	CvCity* addCity();																																					
+	void deleteCity(int iID);																																		
+																																															
+	// unit iteration																																						
+	DllExport CvUnit* firstUnit(int *pIterIdx, bool bRev=false) const;																// Exposed to Python					
+	DllExport CvUnit* nextUnit(int *pIterIdx, bool bRev=false) const;																	// Exposed to Python					
+	DllExport int getNumUnits() const;																																// Exposed to Python					
+	DllExport CvUnit* getUnit(int iID) const;																													// Exposed to Python					
+	CvUnit* addUnit();																																					
+	void deleteUnit(int iID);
+																																															
+	// selection groups iteration																																
+	DllExport CvSelectionGroup* firstSelectionGroup(int *pIterIdx, bool bRev=false) const;						// Exposed to Python					
+	DllExport CvSelectionGroup* nextSelectionGroup(int *pIterIdx, bool bRev=false) const;							// Exposed to Python					
+	int getNumSelectionGroups() const;																																// Exposed to Python
+	CvSelectionGroup* getSelectionGroup(int iID) const;																								// Exposed to Python
+	CvSelectionGroup* addSelectionGroup();
+	void deleteSelectionGroup(int iID);
+
+	// pending triggers iteration																																
+	EventTriggeredData* firstEventTriggered(int *pIterIdx, bool bRev=false) const;
+	EventTriggeredData* nextEventTriggered(int *pIterIdx, bool bRev=false) const;
+	int getNumEventsTriggered() const;
+	EventTriggeredData* getEventTriggered(int iID) const;   // Exposed to Python
+	EventTriggeredData* addEventTriggered();
+	void deleteEventTriggered(int iID);
+	EventTriggeredData* initTriggeredData(EventTriggerTypes eEventTrigger, bool bFire = false, int iCityId = -1, int iPlotX = INVALID_PLOT_COORD, int iPlotY = INVALID_PLOT_COORD, PlayerTypes eOtherPlayer = NO_PLAYER, int iOtherPlayerCityId = -1, ReligionTypes eReligion = NO_RELIGION, CorporationTypes eCorporation = NO_CORPORATION, int iUnitId = -1, BuildingTypes eBuilding = NO_BUILDING);   // Exposed to Python
+	int getEventTriggerWeight(EventTriggerTypes eTrigger) const;    // Exposed to python
+
+	DllExport void addMessage(const CvTalkingHeadMessage& message);
+	void showMissedMessages();
+	void clearMessages();
+	DllExport const CvMessageQueue& getGameMessages() const;
+	DllExport void expireMessages();
+	DllExport void addPopup(CvPopupInfo* pInfo, bool bFront = false);
+	void clearPopups();
+	DllExport CvPopupInfo* popFrontPopup();
+	DllExport const CvPopupQueue& getPopups() const;
+	DllExport void addDiplomacy(CvDiploParameters* pDiplo);
+	void clearDiplomacy();
+	DllExport const CvDiploQueue& getDiplomacy() const;
+	DllExport CvDiploParameters* popFrontDiplomacy();
+	DllExport void showSpaceShip();
+	DllExport void clearSpaceShipPopups();
+
+	int getScoreHistory(int iTurn) const;																								// Exposed to Python
+	void updateScoreHistory(int iTurn, int iBestScore);
+
+	int getEconomyHistory(int iTurn) const;																							// Exposed to Python
+	void updateEconomyHistory(int iTurn, int iBestEconomy);
+	int getIndustryHistory(int iTurn) const;																						// Exposed to Python
+	void updateIndustryHistory(int iTurn, int iBestIndustry);
+	int getAgricultureHistory(int iTurn) const;																					// Exposed to Python
+	void updateAgricultureHistory(int iTurn, int iBestAgriculture);
+	int getPowerHistory(int iTurn) const;																								// Exposed to Python
+	void updatePowerHistory(int iTurn, int iBestPower);
+	int getCultureHistory(int iTurn) const;																							// Exposed to Python
+	void updateCultureHistory(int iTurn, int iBestCulture);
+	int getEspionageHistory(int iTurn) const;																							// Exposed to Python
+	void updateEspionageHistory(int iTurn, int iBestEspionage);
+
+	// Script data needs to be a narrow string for pickling in Python
+	std::string getScriptData() const;																									// Exposed to Python
+	void setScriptData(std::string szNewValue);																					// Exposed to Python
+
+	DllExport const CvString getPbemEmailAddress() const;
+	DllExport void setPbemEmailAddress(const char* szAddress);
+	DllExport const CvString getSmtpHost() const;
+	DllExport void setSmtpHost(const char* szHost);
+
+	const EventTriggeredData* getEventOccured(EventTypes eEvent) const;			// Exposed to python
+	bool isTriggerFired(EventTriggerTypes eEventTrigger) const;
+	void setEventOccured(EventTypes eEvent, const EventTriggeredData& kEventTriggered, bool bOthers = true);
+	void resetEventOccured(EventTypes eEvent, bool bAnnounce = true);													// Exposed to Python
+	void setTriggerFired(const EventTriggeredData& kTriggeredData, bool bOthers = true, bool bAnnounce = true);	
+	void resetTriggerFired(EventTriggerTypes eEventTrigger);
+	void trigger(EventTriggerTypes eEventTrigger);													// Exposed to Python
+	void trigger(const EventTriggeredData& kData);
+	DllExport void applyEvent(EventTypes eEvent, int iTriggeredId, bool bUpdateTrigger = true);
+	bool canDoEvent(EventTypes eEvent, const EventTriggeredData& kTriggeredData) const;
+	TechTypes getBestEventTech(EventTypes eEvent, PlayerTypes eOtherPlayer) const;
+	int getEventCost(EventTypes eEvent, PlayerTypes eOtherPlayer, bool bRandom) const;
+	bool canTrigger(EventTriggerTypes eTrigger, PlayerTypes ePlayer, ReligionTypes eReligion) const;
+	const EventTriggeredData* getEventCountdown(EventTypes eEvent) const;
+	void setEventCountdown(EventTypes eEvent, const EventTriggeredData& kEventTriggered);
+	void resetEventCountdown(EventTypes eEvent);
+
+	bool isFreePromotion(UnitCombatTypes eUnitCombat, PromotionTypes ePromotion) const;
+	void setFreePromotion(UnitCombatTypes eUnitCombat, PromotionTypes ePromotion, bool bFree);
+	bool isFreePromotion(UnitClassTypes eUnitCombat, PromotionTypes ePromotion) const;
+	void setFreePromotion(UnitClassTypes eUnitCombat, PromotionTypes ePromotion, bool bFree);
+
+	PlayerVoteTypes getVote(int iId) const;
+	void setVote(int iId, PlayerVoteTypes ePlayerVote);
+
+	int getUnitExtraCost(UnitClassTypes eUnitClass) const;
+	void setUnitExtraCost(UnitClassTypes eUnitClass, int iCost);
+
+	DllExport bool splitEmpire(int iAreaId);
+	bool canSplitEmpire() const;
+	bool canSplitArea(int iAreaId) const;
+	PlayerTypes getSplitEmpirePlayer(int iAreaId) const;
+	bool getSplitEmpireLeaders(CivLeaderArray& aLeaders) const;
+
+	DllExport void launch(VictoryTypes victoryType);
+
+	bool hasShrine(ReligionTypes eReligion);
+	int getVotes(VoteTypes eVote, VoteSourceTypes eVoteSource) const;   // Exposed to Python
+	void processVoteSourceBonus(VoteSourceTypes eVoteSource, bool bActive);
+	bool canDoResolution(VoteSourceTypes eVoteSource, const VoteSelectionSubData& kData) const;
+	bool canDefyResolution(VoteSourceTypes eVoteSource, const VoteSelectionSubData& kData) const;
+	void setDefiedResolution(VoteSourceTypes eVoteSource, const VoteSelectionSubData& kData);
+	void setEndorsedResolution(VoteSourceTypes eVoteSource, const VoteSelectionSubData& kData);
+	bool isFullMember(VoteSourceTypes eVoteSource) const;    // Exposed to Python
+	bool isVotingMember(VoteSourceTypes eVoteSource) const;    // Exposed to Python
+
+	void invalidatePopulationRankCache();
+	void invalidateYieldRankCache(YieldTypes eYield = NO_YIELD);
+	void invalidateCommerceRankCache(CommerceTypes eCommerce = NO_COMMERCE);
+
+	PlayerTypes pickConqueredCityOwner(const CvCity& kCity) const;
+	bool canHaveTradeRoutesWith(PlayerTypes ePlayer) const;
+
+	void forcePeace(PlayerTypes ePlayer);    // exposed to Python
+
+	bool canSpiesEnterBorders(PlayerTypes ePlayer) const;
+	int getNewCityProductionValue() const;
+
+	int getGrowthThreshold(int iPopulation) const;
+
+	void verifyUnitStacksValid();
+	UnitTypes getTechFreeUnit(TechTypes eTech) const;
+
+	DllExport void buildTradeTable(PlayerTypes eOtherPlayer, CLinkList<TradeData>& ourList) const;
+	DllExport bool getHeadingTradeString(PlayerTypes eOtherPlayer, TradeableItems eItem, CvWString& szString, CvString& szIcon) const;
+	DllExport bool getItemTradeString(PlayerTypes eOtherPlayer, bool bOffer, bool bShowingCurrent, const TradeData& zTradeData, CvWString& szString, CvString& szIcon) const;
+	DllExport void updateTradeList(PlayerTypes eOtherPlayer, CLinkList<TradeData>& ourInventory, const CLinkList<TradeData>& ourOffer, const CLinkList<TradeData>& theirOffer) const;
+	DllExport int getIntroMusicScriptId(PlayerTypes eForPlayer) const;
+	DllExport int getMusicScriptId(PlayerTypes eForPlayer) const;
+	DllExport void getGlobeLayerColors(GlobeLayerTypes eGlobeLayerType, int iOption, std::vector<NiColorA>& aColors, std::vector<CvPlotIndicatorData>& aIndicators) const;
+	DllExport void cheat(bool bCtrl, bool bAlt, bool bShift);
+
+	DllExport const CvArtInfoUnit* getUnitArtInfo(UnitTypes eUnit, int iMeshGroup = 0) const;
+	DllExport bool hasSpaceshipArrived() const;
+
+	virtual void AI_init() = 0;
+	virtual void AI_reset(bool bConstructor) = 0;
+	virtual void AI_doTurnPre() = 0;
+	virtual void AI_doTurnPost() = 0;
+	virtual void AI_doTurnUnitsPre() = 0;
+	virtual void AI_doTurnUnitsPost() = 0;
+	virtual void AI_updateFoundValues(bool bStartingLoc = false) const = 0;
+	virtual void AI_unitUpdate() = 0;
+	virtual void AI_makeAssignWorkDirty() = 0;
+	virtual void AI_assignWorkingPlots() = 0;
+	virtual void AI_updateAssignWork() = 0;
+	virtual void AI_makeProductionDirty() = 0;
+	virtual void AI_conquerCity(CvCity* pCity) = 0;
+	virtual int AI_foundValue(int iX, int iY, int iMinUnitRange = -1, bool bStartingLoc = false) const = 0; // Exposed to Python
+	virtual bool AI_isCommercePlot(CvPlot* pPlot) const = 0;
+	virtual int AI_getPlotDanger(CvPlot* pPlot, int iRange = -1, bool bTestMoves = true) const = 0;
+	virtual bool AI_isFinancialTrouble() const = 0;																											// Exposed to Python
+	virtual TechTypes AI_bestTech(int iMaxPathLength = 1, bool bIgnoreCost = false, bool bAsync = false, TechTypes eIgnoreTech = NO_TECH, AdvisorTypes eIgnoreAdvisor = NO_ADVISOR) const = 0;
+	virtual void AI_chooseFreeTech() = 0;
+	virtual void AI_chooseResearch() = 0;
+	virtual bool AI_isWillingToTalk(PlayerTypes ePlayer) const = 0;
+	virtual bool AI_demandRebukedSneak(PlayerTypes ePlayer) const = 0;
+	virtual bool AI_demandRebukedWar(PlayerTypes ePlayer) const = 0;																		// Exposed to Python
+	virtual AttitudeTypes AI_getAttitude(PlayerTypes ePlayer, bool bForced = true) const = 0;																// Exposed to Python
+	virtual PlayerVoteTypes AI_diploVote(const VoteSelectionSubData& kVoteData, VoteSourceTypes eVoteSource, bool bPropose) = 0;
+	virtual int AI_dealVal(PlayerTypes ePlayer, const CLinkList<TradeData>* pList, bool bIgnoreAnnual = false, int iExtra = 0) const = 0;
+	virtual bool AI_considerOffer(PlayerTypes ePlayer, const CLinkList<TradeData>* pTheirList, const CLinkList<TradeData>* pOurList, int iChange = 1) const = 0;
+	virtual bool AI_counterPropose(PlayerTypes ePlayer, const CLinkList<TradeData>* pTheirList, const CLinkList<TradeData>* pOurList, CLinkList<TradeData>* pTheirInventory, CLinkList<TradeData>* pOurInventory, CLinkList<TradeData>* pTheirCounter, CLinkList<TradeData>* pOurCounter) const = 0;
+	virtual int AI_bonusVal(BonusTypes eBonus, int iChange = 0) const = 0;
+	virtual int AI_bonusTradeVal(BonusTypes eBonus, PlayerTypes ePlayer, int iChange = 0) const = 0;
+	virtual DenialTypes AI_bonusTrade(BonusTypes eBonus, PlayerTypes ePlayer) const = 0;
+	virtual int AI_cityTradeVal(CvCity* pCity) const = 0;
+	virtual DenialTypes AI_cityTrade(CvCity* pCity, PlayerTypes ePlayer) const = 0;
+	virtual DenialTypes AI_stopTradingTrade(TeamTypes eTradeTeam, PlayerTypes ePlayer) const = 0;
+	virtual DenialTypes AI_civicTrade(CivicTypes eCivic, PlayerTypes ePlayer) const = 0;
+	virtual DenialTypes AI_religionTrade(ReligionTypes eReligion, PlayerTypes ePlayer) const = 0;
+	virtual int AI_unitValue(UnitTypes eUnit, UnitAITypes eUnitAI, CvArea* pArea) const = 0;						// Exposed to Python
+	virtual int AI_totalUnitAIs(UnitAITypes eUnitAI) const = 0;																					// Exposed to Python
+	virtual int AI_totalAreaUnitAIs(CvArea* pArea, UnitAITypes eUnitAI) const = 0;											// Exposed to Python
+	virtual int AI_totalWaterAreaUnitAIs(CvArea* pArea, UnitAITypes eUnitAI) const = 0;									// Exposed to Python
+	virtual int AI_plotTargetMissionAIs(CvPlot* pPlot, MissionAITypes eMissionAI, CvSelectionGroup* pSkipSelectionGroup = NULL, int iRange = 0) const = 0;
+	virtual int AI_unitTargetMissionAIs(CvUnit* pUnit, MissionAITypes eMissionAI, CvSelectionGroup* pSkipSelectionGroup = NULL) const = 0;
+	virtual int AI_civicValue(CivicTypes eCivic) const = 0;   // Exposed to Python
+	virtual int AI_getNumAIUnits(UnitAITypes eIndex) const = 0;																					// Exposed to Python
+	virtual void AI_changePeacetimeTradeValue(PlayerTypes eIndex, int iChange) = 0;
+	virtual void AI_changePeacetimeGrantValue(PlayerTypes eIndex, int iChange) = 0;
+	virtual int AI_getAttitudeExtra(PlayerTypes eIndex) const = 0;																			// Exposed to Python
+	virtual void AI_setAttitudeExtra(PlayerTypes eIndex, int iNewValue) = 0;											// Exposed to Python
+	virtual void AI_changeAttitudeExtra(PlayerTypes eIndex, int iChange) = 0;											// Exposed to Python
+	virtual void AI_setFirstContact(PlayerTypes eIndex, bool bNewValue) = 0;
+	virtual int AI_getMemoryCount(PlayerTypes eIndex1, MemoryTypes eIndex2) const = 0;
+	virtual void AI_changeMemoryCount(PlayerTypes eIndex1, MemoryTypes eIndex2, int iChange) = 0;
+	virtual void AI_doCommerce() = 0;
+	virtual EventTypes AI_chooseEvent(int iTriggeredId) const = 0;
+	virtual void AI_launch(VictoryTypes eVictory) = 0;
+	virtual void AI_doAdvancedStart(bool bNoExit = false) = 0;
+	virtual void AI_updateBonusValue() = 0;
+	virtual void AI_updateBonusValue(BonusTypes eBonus) = 0;
+	virtual ReligionTypes AI_chooseReligion() = 0;
+	virtual int AI_getExtraGoldTarget() const = 0;
+	virtual void AI_setExtraGoldTarget(int iNewValue) = 0;
+	virtual int AI_maxGoldPerTurnTrade(PlayerTypes ePlayer) const = 0;
+	virtual int AI_maxGoldTrade(PlayerTypes ePlayer) const = 0;
+
+protected:
+
+	int m_iStartingX;
+	int m_iStartingY;
+	int m_iTotalPopulation;
+	int m_iTotalLand;
+	int m_iTotalLandScored;
+	int m_iGold;
+	int m_iGoldPerTurn;
+	int m_iAdvancedStartPoints;
+	int m_iGoldenAgeTurns;
+	int m_iNumUnitGoldenAges;
+	int m_iStrikeTurns;
+	int m_iAnarchyTurns;
+	int m_iMaxAnarchyTurns;
+	int m_iAnarchyModifier;
+	int m_iGoldenAgeModifier;
+	int m_iGlobalHurryModifier;
+	int m_iGreatPeopleCreated;
+	int m_iGreatGeneralsCreated;
+	int m_iGreatPeopleThresholdModifier;
+	int m_iGreatGeneralsThresholdModifier;
+	int m_iGreatPeopleRateModifier;
+	int m_iGreatGeneralRateModifier;
+	int m_iDomesticGreatGeneralRateModifier;
+	int m_iStateReligionGreatPeopleRateModifier;
+	int m_iMaxGlobalBuildingProductionModifier;
+	int m_iMaxTeamBuildingProductionModifier;
+	int m_iMaxPlayerBuildingProductionModifier;
+	int m_iFreeExperience;
+	int m_iFeatureProductionModifier;
+	int m_iWorkerSpeedModifier;
+	int m_iImprovementUpgradeRateModifier;
+	int m_iMilitaryProductionModifier;
+	int m_iSpaceProductionModifier;
+	int m_iCityDefenseModifier;
+	int m_iNumNukeUnits;
+	int m_iNumOutsideUnits;
+	int m_iBaseFreeUnits;
+	int m_iBaseFreeMilitaryUnits;
+	int m_iFreeUnitsPopulationPercent;
+	int m_iFreeMilitaryUnitsPopulationPercent;
+	int m_iGoldPerUnit;
+	int m_iGoldPerMilitaryUnit;
+	int m_iExtraUnitCost;
+	int m_iNumMilitaryUnits;
+	int m_iHappyPerMilitaryUnit;
+	int m_iMilitaryFoodProductionCount;
+	int m_iConscriptCount;
+	int m_iMaxConscript;
+	int m_iHighestUnitLevel;
+	int m_iOverflowResearch;
+	int m_iNoUnhealthyPopulationCount;
+	int m_iExpInBorderModifier;
+	int m_iBuildingOnlyHealthyCount;
+	int m_iDistanceMaintenanceModifier;
+	int m_iNumCitiesMaintenanceModifier;
+	int m_iCorporationMaintenanceModifier;
+	int m_iTotalMaintenance;
+	int m_iUpkeepModifier;
+	int m_iLevelExperienceModifier;
+	int m_iExtraHealth;
+	int m_iBuildingGoodHealth;
+	int m_iBuildingBadHealth;
+	int m_iExtraHappiness;
+	int m_iBuildingHappiness;
+	int m_iLargestCityHappiness;
+	int m_iWarWearinessPercentAnger;
+	int m_iWarWearinessModifier;
+	int m_iFreeSpecialist;
+	int m_iNoForeignTradeCount;
+	int m_iNoCorporationsCount;
+	int m_iNoForeignCorporationsCount;
+	int m_iCoastalTradeRoutes;
+	int m_iTradeRoutes;
+	int m_iRevolutionTimer;
+	int m_iConversionTimer;
+	int m_iStateReligionCount;
+	int m_iNoNonStateReligionSpreadCount;
+	int m_iStateReligionHappiness;
+	int m_iNonStateReligionHappiness;
+	int m_iStateReligionUnitProductionModifier;
+	int m_iStateReligionBuildingProductionModifier;
+	int m_iStateReligionFreeExperience;
+	int m_iCapitalCityID;
+	int m_iCitiesLost;
+	int m_iWinsVsBarbs;
+	int m_iAssets;
+	int m_iPower;
+	int m_iPopulationScore;
+	int m_iLandScore;
+	int m_iTechScore;
+	int m_iWondersScore;
+	int m_iCombatExperience;
+	int m_iPopRushHurryCount;
+	int m_iInflationModifier;
+
+	uint m_uiStartTime;  // XXX save these?
+
+	bool m_bAlive;
+	bool m_bEverAlive;
+	bool m_bTurnActive;
+	bool m_bAutoMoves;
+	bool m_bEndTurn;
+	bool m_bPbemNewTurn;
+	bool m_bExtendedGame;
+	bool m_bFoundedFirstCity;
+	bool m_bStrike;
+	bool m_bHuman;
+	
+	// RBMP Free Tech Popup Fix
+	bool m_bChoosingFreeTech;
+
+	PlayerTypes m_eID;
+	LeaderHeadTypes m_ePersonalityType;
+	EraTypes m_eCurrentEra;
+	ReligionTypes m_eLastStateReligion;
+	PlayerTypes m_eParent;
+	TeamTypes m_eTeamType;
+
+	int* m_aiSeaPlotYield;
+	int* m_aiYieldRateModifier;
+	int* m_aiCapitalYieldRateModifier;
+	int* m_aiExtraYieldThreshold;
+	int* m_aiTradeYieldModifier;
+	int* m_aiFreeCityCommerce;
+	int* m_aiCommercePercent;
+	int* m_aiCommerceRate;
+	int* m_aiCommerceRateModifier;
+	int* m_aiCapitalCommerceRateModifier;
+	int* m_aiStateReligionBuildingCommerce;
+	int* m_aiSpecialistExtraCommerce;
+	int* m_aiCommerceFlexibleCount;
+	int* m_aiGoldPerTurnByPlayer;
+	int* m_aiEspionageSpendingWeightAgainstTeam;
+
+	bool* m_abFeatAccomplished;
+	bool* m_abOptions;
+
+	CvString m_szScriptData;
+
+	int* m_paiBonusExport;
+	int* m_paiBonusImport;
+	int* m_paiImprovementCount;
+	int* m_paiFreeBuildingCount;
+	int* m_paiExtraBuildingHappiness;
+	int* m_paiExtraBuildingHealth;
+	int** m_paiExtraBuildingYield;
+	int** m_paiExtraBuildingCommerce;
+	int* m_paiFeatureHappiness;
+	int* m_paiUnitClassCount;
+	int* m_paiUnitClassMaking;
+	int* m_paiBuildingClassCount;
+	int* m_paiBuildingClassMaking;
+	int* m_paiHurryCount;
+	int* m_paiSpecialBuildingNotRequiredCount;
+	int* m_paiHasCivicOptionCount;
+	int* m_paiNoCivicUpkeepCount;
+	int* m_paiHasReligionCount;
+	int* m_paiHasCorporationCount;
+	int* m_paiUpkeepCount;
+	int* m_paiSpecialistValidCount;
+
+	bool* m_pabResearchingTech;
+	bool* m_pabLoyalMember;
+
+	std::vector<EventTriggerTypes> m_triggersFired;
+
+	CivicTypes* m_paeCivics;
+
+	int** m_ppaaiSpecialistExtraYield;
+	int** m_ppaaiImprovementYieldChange;
+
+	CLinkList<int> m_groupCycle;
+
+	CLinkList<TechTypes> m_researchQueue;
+
+	CLinkList<CvWString> m_cityNames;
+
+	FFreeListTrashArray<CvPlotGroup> m_plotGroups;
+
+	FFreeListTrashArray<CvCityAI> m_cities;
+
+	FFreeListTrashArray<CvUnitAI> m_units;
+
+	FFreeListTrashArray<CvSelectionGroupAI> m_selectionGroups;
+
+	FFreeListTrashArray<EventTriggeredData> m_eventsTriggered;
+	CvEventMap m_mapEventsOccured;
+	CvEventMap m_mapEventCountdown;
+	UnitCombatPromotionArray m_aFreeUnitCombatPromotions;
+	UnitClassPromotionArray m_aFreeUnitClassPromotions;
+
+	std::vector< std::pair<int, PlayerVoteTypes> > m_aVote;
+	std::vector< std::pair<UnitClassTypes, int> > m_aUnitExtraCosts;
+
+	CvMessageQueue m_listGameMessages; 
+	CvPopupQueue m_listPopups;
+	CvDiploQueue m_listDiplomacy; 
+
+	CvTurnScoreMap m_mapScoreHistory;
+	CvTurnScoreMap m_mapEconomyHistory;
+	CvTurnScoreMap m_mapIndustryHistory;
+	CvTurnScoreMap m_mapAgricultureHistory;
+	CvTurnScoreMap m_mapPowerHistory;
+	CvTurnScoreMap m_mapCultureHistory;
+	CvTurnScoreMap m_mapEspionageHistory;
+
+	void doGold();
+	void doResearch();
+	void doEspionagePoints();
+	void doWarnings();
+	void doEvents();
+
+	bool checkExpireEvent(EventTypes eEvent, const EventTriggeredData& kTriggeredData) const;
+	void expireEvent(EventTypes eEvent, const EventTriggeredData& kTriggeredData, bool bFail);
+	bool isValidTriggerReligion(const CvEventTriggerInfo& kTrigger, CvCity* pCity, ReligionTypes eReligion) const;
+	bool isValidTriggerCorporation(const CvEventTriggerInfo& kTrigger, CvCity* pCity, CorporationTypes eCorporation) const;
+	CvCity* pickTriggerCity(EventTriggerTypes eTrigger) const;
+	CvUnit* pickTriggerUnit(EventTriggerTypes eTrigger, CvPlot* pPlot, bool bPickPlot) const;
+	bool isValidEventTech(TechTypes eTech, EventTypes eEvent, PlayerTypes eOtherPlayer) const;
+
+	void verifyGoldCommercePercent();
+
+	void processCivics(CivicTypes eCivic, int iChange);
+
+	// for serialization
+	virtual void read(FDataStreamBase* pStream);
+	virtual void write(FDataStreamBase* pStream);
+	
+	void doUpdateCacheOnTurn();	
+	int getResearchTurnsLeftTimes100(TechTypes eTech, bool bOverflow) const;
+
+	void getTradeLayerColors(std::vector<NiColorA>& aColors, std::vector<CvPlotIndicatorData>& aIndicators) const;  // used by Globeview trade layer
+	void getUnitLayerColors(GlobeLayerUnitOptionTypes eOption, std::vector<NiColorA>& aColors, std::vector<CvPlotIndicatorData>& aIndicators) const;  // used by Globeview unit layer
+	void getResourceLayerColors(GlobeLayerResourceOptionTypes eOption, std::vector<NiColorA>& aColors, std::vector<CvPlotIndicatorData>& aIndicators) const;  // used by Globeview resource layer
+	void getReligionLayerColors(ReligionTypes eSelectedReligion, std::vector<NiColorA>& aColors, std::vector<CvPlotIndicatorData>& aIndicators) const;  // used by Globeview religion layer
+	void getCultureLayerColors(std::vector<NiColorA>& aColors, std::vector<CvPlotIndicatorData>& aIndicators) const;  // used by Globeview culture layer
+};
+
+#endif

--- a/CvPlot.cpp
+++ b/CvPlot.cpp
@@ -430,7 +430,9 @@ void CvPlot::doImprovement()
 				{
 					if (GC.getImprovementInfo(getImprovementType()).getImprovementBonusDiscoverRand(iI) > 0)
 					{
-						if (GC.getGameINLINE().getSorenRandNum(GC.getImprovementInfo(getImprovementType()).getImprovementBonusDiscoverRand(iI), "Bonus Discovery") == 0)
+						// RBMP game speed scaling: * 100 / GC.getGameSpeedInfo(GC.getGameINLINE().getGameSpeedType()).getImprovementPercent()
+						if (GC.getGameINLINE().getSorenRandNum(GC.getImprovementInfo(getImprovementType()).getImprovementBonusDiscoverRand(iI) * 100 /
+							GC.getGameSpeedInfo(GC.getGameINLINE().getGameSpeedType()).getImprovementPercent(), "Bonus Discovery") == 0)
 						{
 							setBonusType((BonusTypes)iI);
 
@@ -8110,7 +8112,8 @@ void CvPlot::doFeature()
 
 	if (getFeatureType() != NO_FEATURE)
 	{
-		iProbability = GC.getFeatureInfo(getFeatureType()).getDisappearanceProbability();
+		// RBMP game speed scaling: * 100 / GC.getGameSpeedInfo(GC.getGameINLINE().getGameSpeedType()).getImprovementPercent()
+		iProbability = GC.getFeatureInfo(getFeatureType()).getDisappearanceProbability() * 100 / GC.getGameSpeedInfo(GC.getGameINLINE().getGameSpeedType()).getImprovementPercent();
 
 		if (iProbability > 0)
 		{
@@ -8162,6 +8165,9 @@ void CvPlot::doFeature()
 								iProbability *= std::max(0, (GC.getROUTE_FEATURE_GROWTH_MODIFIER() + 100));
 								iProbability /= 100;
 							}
+
+							// RBMP game speed scaling:
+							iProbability = iProbability * 100 / GC.getGameSpeedInfo(GC.getGameINLINE().getGameSpeedType()).getImprovementPercent();
 
 							if (iProbability > 0)
 							{


### PR DESCRIPTION
Included fixes for:
- Lib/oracle multiple techs
- Trade route turn order bug
- Foreign trade route cities lost permanently when your city using those
  routes is destroyed
- Build culture double production
- Build wealth/research/culture + production automation double
  production
- Proposed trades including cities, where the cities no longer exist to
  be trades, are not cancelled
- Production decay counter on a type of build (e.g. axeman) is not reset
  after completing one if the next item in the queue is of the same type
- Feature growth/disappearance rates, and bonus discovery (mine pop)
  rates, do not scale with game speed
